### PR TITLE
 Fix J25 deck format and improve batch reformatter

### DIFF
--- a/etc/J25/ANGELS (1).txt
+++ b/etc/J25/ANGELS (1).txt
@@ -1,3 +1,4 @@
+ANGELS (1)
 Giada, Font of Hope
 Faithful Pikemaster
 Starnheim Memento

--- a/etc/J25/ANGELS (2).txt
+++ b/etc/J25/ANGELS (2).txt
@@ -1,3 +1,4 @@
+ANGELS (2)
 Giada, Font of Hope
 Herald of War
 Faithful Pikemaster

--- a/etc/J25/ARMED (1).txt
+++ b/etc/J25/ARMED (1).txt
@@ -1,3 +1,4 @@
+ARMED (1)
 Mace of the Valiant
 Faithful Pikemaster
 Starnheim Memento

--- a/etc/J25/ARMED (2).txt
+++ b/etc/J25/ARMED (2).txt
@@ -1,3 +1,4 @@
+ARMED (2)
 Stone Haven Outfitter
 Faithful Pikemaster
 Danitha Capashen, Paragon

--- a/etc/J25/ARMED (3).txt
+++ b/etc/J25/ARMED (3).txt
@@ -1,3 +1,4 @@
+ARMED (3)
 Maul of the Skyclaves
 Faithful Pikemaster
 Danitha Capashen, Paragon

--- a/etc/J25/ARMED (4).txt
+++ b/etc/J25/ARMED (4).txt
@@ -1,3 +1,4 @@
+ARMED (4)
 Godsend
 Faithful Pikemaster
 Danitha Capashen, Paragon

--- a/etc/J25/BEASTS (1).txt
+++ b/etc/J25/BEASTS (1).txt
@@ -1,3 +1,4 @@
+BEASTS (1)
 Slinza, the Spiked Stampede
 Hungry Megasloth
 Spined Tyrranax

--- a/etc/J25/BEASTS (2).txt
+++ b/etc/J25/BEASTS (2).txt
@@ -1,3 +1,4 @@
+BEASTS (2)
 Slinza, the Spiked Stampede
 Garruk, Caller of Beasts
 Hungry Megasloth

--- a/etc/J25/BLOODY (1).txt
+++ b/etc/J25/BLOODY (1).txt
@@ -1,3 +1,4 @@
+BLOODY (1)
 Anje's Ravager
 Ivora, Insatiable Heir
 Abandon Reason

--- a/etc/J25/BLOODY (2).txt
+++ b/etc/J25/BLOODY (2).txt
@@ -1,3 +1,4 @@
+BLOODY (2)
 Markov Blademaster
 Markov Enforcer
 Ivora, Insatiable Heir

--- a/etc/J25/BLOODY (3).txt
+++ b/etc/J25/BLOODY (3).txt
@@ -1,3 +1,4 @@
+BLOODY (3)
 Scion of Opulence
 Ivora, Insatiable Heir
 Blood Feud

--- a/etc/J25/BLOODY (4).txt
+++ b/etc/J25/BLOODY (4).txt
@@ -1,3 +1,4 @@
+BLOODY (4)
 Falkenrath Marauders
 Ivora, Insatiable Heir
 Blood Feud

--- a/etc/J25/BOOKWORMS (1).txt
+++ b/etc/J25/BOOKWORMS (1).txt
@@ -1,3 +1,4 @@
+BOOKWORMS (1)
 Overflowing Insight
 Starlight Snare
 Syr Elenora, the Discerning

--- a/etc/J25/BOOKWORMS (2).txt
+++ b/etc/J25/BOOKWORMS (2).txt
@@ -1,3 +1,4 @@
+BOOKWORMS (2)
 Teferi's Ageless Insight
 Phantasmal Shieldback
 Starlight Snare

--- a/etc/J25/BOOKWORMS (3).txt
+++ b/etc/J25/BOOKWORMS (3).txt
@@ -1,3 +1,4 @@
+BOOKWORMS (3)
 Sphinx of Enlightenment
 Starlight Snare
 Syr Elenora, the Discerning

--- a/etc/J25/BOOKWORMS (4).txt
+++ b/etc/J25/BOOKWORMS (4).txt
@@ -1,3 +1,4 @@
+BOOKWORMS (4)
 Nadir Kraken
 Phantasmal Shieldback
 Starlight Snare

--- a/etc/J25/BURNING.txt
+++ b/etc/J25/BURNING.txt
@@ -1,3 +1,4 @@
+BURNING
 Rionya, Fire Dancer
 Firespitter Whelp
 Hearts on Fire

--- a/etc/J25/CHAOS.txt
+++ b/etc/J25/CHAOS.txt
@@ -1,3 +1,4 @@
+CHAOS
 Averna, the Chaos Bloom
 Shardless Outlander
 Chromatic Lantern

--- a/etc/J25/CLERICS (1).txt
+++ b/etc/J25/CLERICS (1).txt
@@ -1,3 +1,4 @@
+CLERICS (1)
 Taborax, Hope's Demise
 Nullpriest of Oblivion
 Revoke Demise

--- a/etc/J25/CLERICS (2).txt
+++ b/etc/J25/CLERICS (2).txt
@@ -1,3 +1,4 @@
+CLERICS (2)
 Taborax, Hope's Demise
 Revoke Demise
 Bonecaller Cleric

--- a/etc/J25/CLERICS (3).txt
+++ b/etc/J25/CLERICS (3).txt
@@ -1,3 +1,4 @@
+CLERICS (3)
 Vito, Thorn of the Dusk Rose
 Revoke Demise
 Bonecaller Cleric

--- a/etc/J25/CLERICS (4).txt
+++ b/etc/J25/CLERICS (4).txt
@@ -1,3 +1,4 @@
+CLERICS (4)
 Vito, Thorn of the Dusk Rose
 Priest of Forgotten Gods
 Revoke Demise

--- a/etc/J25/COPIED (1).txt
+++ b/etc/J25/COPIED (1).txt
@@ -1,3 +1,4 @@
+COPIED (1)
 Zada, Hedron Grinder
 Scholar of Combustion
 Guttersnipe

--- a/etc/J25/COPIED (2).txt
+++ b/etc/J25/COPIED (2).txt
@@ -1,3 +1,4 @@
+COPIED (2)
 Zada, Hedron Grinder
 Charmbreaker Devils
 Firespitter Whelp

--- a/etc/J25/DINNER.txt
+++ b/etc/J25/DINNER.txt
@@ -1,3 +1,4 @@
+DINNER
 Hurska Sweet-Tooth
 Saurian Symbiote
 Bite Down

--- a/etc/J25/DINOSAURS (1).txt
+++ b/etc/J25/DINOSAURS (1).txt
@@ -1,3 +1,4 @@
+DINOSAURS (1)
 Ghalta, Primal Hunger
 Saurian Symbiote
 Armored Kincaller

--- a/etc/J25/DINOSAURS (2).txt
+++ b/etc/J25/DINOSAURS (2).txt
@@ -1,3 +1,4 @@
+DINOSAURS (2)
 Ghalta, Primal Hunger
 Topiary Stomper
 Saurian Symbiote

--- a/etc/J25/DRAGONS (1).txt
+++ b/etc/J25/DRAGONS (1).txt
@@ -1,3 +1,4 @@
+DRAGONS (1)
 Lathliss, Dragon Queen
 Firespitter Whelp
 Carnelian Orb of Dragonkind

--- a/etc/J25/DRAGONS (2).txt
+++ b/etc/J25/DRAGONS (2).txt
@@ -1,3 +1,4 @@
+DRAGONS (2)
 Lathliss, Dragon Queen
 Sarkhan, Fireblood
 Firespitter Whelp

--- a/etc/J25/DROWNED (1).txt
+++ b/etc/J25/DROWNED (1).txt
@@ -1,3 +1,4 @@
+DROWNED (1)
 Neerdiv, Devious Diver
 Sudden Insight
 Deep Analysis

--- a/etc/J25/DROWNED (2).txt
+++ b/etc/J25/DROWNED (2).txt
@@ -1,3 +1,4 @@
+DROWNED (2)
 Neerdiv, Devious Diver
 Cackling Counterpart
 Sudden Insight

--- a/etc/J25/ELVES (1).txt
+++ b/etc/J25/ELVES (1).txt
@@ -1,3 +1,4 @@
+ELVES (1)
 Leaf-Crowned Visionary
 Razorgrass Invoker
 Dionus, Elvish Archdruid

--- a/etc/J25/ELVES (2).txt
+++ b/etc/J25/ELVES (2).txt
@@ -1,3 +1,4 @@
+ELVES (2)
 Elvish Archdruid
 Razorgrass Invoker
 Dionus, Elvish Archdruid

--- a/etc/J25/ELVES (3).txt
+++ b/etc/J25/ELVES (3).txt
@@ -1,3 +1,4 @@
+ELVES (3)
 Marwyn, the Nurturer
 Go Forth
 Razorgrass Invoker

--- a/etc/J25/ELVES (4).txt
+++ b/etc/J25/ELVES (4).txt
@@ -1,3 +1,4 @@
+ELVES (4)
 Tyvar Kell
 Voice of the Woods
 Dionus, Elvish Archdruid

--- a/etc/J25/ENCHANTED (1).txt
+++ b/etc/J25/ENCHANTED (1).txt
@@ -1,3 +1,4 @@
+ENCHANTED (1)
 Eidolon of Astral Winds
 Psemilla, Meletian Poet
 Banishing Light

--- a/etc/J25/ENCHANTED (2).txt
+++ b/etc/J25/ENCHANTED (2).txt
@@ -1,3 +1,4 @@
+ENCHANTED (2)
 Eidolon of Astral Winds
 Psemilla, Meletian Poet
 Banishing Light

--- a/etc/J25/ENCHANTED (3).txt
+++ b/etc/J25/ENCHANTED (3).txt
@@ -1,3 +1,4 @@
+ENCHANTED (3)
 Nykthos Paragon
 Starfield Mystic
 Psemilla, Meletian Poet

--- a/etc/J25/ENCHANTED (4).txt
+++ b/etc/J25/ENCHANTED (4).txt
@@ -1,3 +1,4 @@
+ENCHANTED (4)
 Archon of Sun's Grace
 Psemilla, Meletian Poet
 Banishing Light

--- a/etc/J25/ENCOUNTER (1).txt
+++ b/etc/J25/ENCOUNTER (1).txt
@@ -1,3 +1,4 @@
+ENCOUNTER (1)
 Forgotten Ancient
 Spined Tyrranax
 Mowu, Loyal Companion

--- a/etc/J25/ENCOUNTER (2).txt
+++ b/etc/J25/ENCOUNTER (2).txt
@@ -1,3 +1,4 @@
+ENCOUNTER (2)
 Oran-Rief Ooze
 Saurian Symbiote
 Spined Tyrranax

--- a/etc/J25/ENCOUNTER (3).txt
+++ b/etc/J25/ENCOUNTER (3).txt
@@ -1,3 +1,4 @@
+ENCOUNTER (3)
 Rishkar, Peema Renegade
 Saurian Symbiote
 Spined Tyrranax

--- a/etc/J25/ENCOUNTER (4).txt
+++ b/etc/J25/ENCOUNTER (4).txt
@@ -1,3 +1,4 @@
+ENCOUNTER (4)
 Primeval Bounty
 Quirion Beastcaller
 Hungry Megasloth

--- a/etc/J25/EXPLORERS (1).txt
+++ b/etc/J25/EXPLORERS (1).txt
@@ -1,3 +1,4 @@
+EXPLORERS (1)
 Realm Seekers
 Go Forth
 Razorgrass Invoker

--- a/etc/J25/EXPLORERS (2).txt
+++ b/etc/J25/EXPLORERS (2).txt
@@ -1,3 +1,4 @@
+EXPLORERS (2)
 Tireless Tracker
 Go Forth
 Razorgrass Invoker

--- a/etc/J25/EXPLORERS (3).txt
+++ b/etc/J25/EXPLORERS (3).txt
@@ -1,3 +1,4 @@
+EXPLORERS (3)
 Briarbridge Tracker
 Somberwald Beastmaster
 Go Forth

--- a/etc/J25/EXPLORERS (4).txt
+++ b/etc/J25/EXPLORERS (4).txt
@@ -1,3 +1,4 @@
+EXPLORERS (4)
 Jadelight Ranger
 Go Forth
 Razorgrass Invoker

--- a/etc/J25/FUN GUYS (1).txt
+++ b/etc/J25/FUN GUYS (1).txt
@@ -1,3 +1,4 @@
+FUN GUYS (1)
 Shroofus Sproutsire
 Saurian Symbiote
 Slimy Piper

--- a/etc/J25/FUN GUYS (2).txt
+++ b/etc/J25/FUN GUYS (2).txt
@@ -1,3 +1,4 @@
+FUN GUYS (2)
 Shroofus Sproutsire
 Verdeloth the Ancient
 Saurian Symbiote

--- a/etc/J25/GHASTLY (1).txt
+++ b/etc/J25/GHASTLY (1).txt
@@ -1,3 +1,4 @@
+GHASTLY (1)
 Harvester of Souls
 Ozox, the Clattering King
 Blood Beckoning

--- a/etc/J25/GHASTLY (2).txt
+++ b/etc/J25/GHASTLY (2).txt
@@ -1,3 +1,4 @@
+GHASTLY (2)
 Bloodgift Demon
 Ozox, the Clattering King
 Blood Beckoning

--- a/etc/J25/GHASTLY (3).txt
+++ b/etc/J25/GHASTLY (3).txt
@@ -1,3 +1,4 @@
+GHASTLY (3)
 Reaper from the Abyss
 Wriggling Grub
 Ozox, the Clattering King

--- a/etc/J25/GHASTLY (4).txt
+++ b/etc/J25/GHASTLY (4).txt
@@ -1,3 +1,4 @@
+GHASTLY (4)
 Army of the Damned
 Ozox, the Clattering King
 Deadly Dispute

--- a/etc/J25/GIDDYAP.txt
+++ b/etc/J25/GIDDYAP.txt
@@ -1,3 +1,4 @@
+GIDDYAP
 Thurid, Mare of Destiny
 Banishing Light
 Celestial Unicorn

--- a/etc/J25/GOBLINS (1).txt
+++ b/etc/J25/GOBLINS (1).txt
@@ -1,3 +1,4 @@
+GOBLINS (1)
 Dropkick Bomber
 Goblin Surprise
 General Kreat, the Boltbringer

--- a/etc/J25/GOBLINS (2).txt
+++ b/etc/J25/GOBLINS (2).txt
@@ -1,3 +1,4 @@
+GOBLINS (2)
 Dropkick Bomber
 Goblin Goliath
 Goblin Surprise

--- a/etc/J25/GOBLINS (3).txt
+++ b/etc/J25/GOBLINS (3).txt
@@ -1,3 +1,4 @@
+GOBLINS (3)
 Krenko, Tin Street Kingpin
 Goblin Surprise
 General Kreat, the Boltbringer

--- a/etc/J25/GOBLINS (4).txt
+++ b/etc/J25/GOBLINS (4).txt
@@ -1,3 +1,4 @@
+GOBLINS (4)
 Goblin Rabblemaster
 Goblin Surprise
 General Kreat, the Boltbringer

--- a/etc/J25/GRAVE ROBBERS (1).txt
+++ b/etc/J25/GRAVE ROBBERS (1).txt
@@ -1,3 +1,4 @@
+GRAVE ROBBERS (1)
 Gorex, the Tombshell
 Revoke Demise
 Eternal Taskmaster

--- a/etc/J25/GRAVE ROBBERS (2).txt
+++ b/etc/J25/GRAVE ROBBERS (2).txt
@@ -1,3 +1,4 @@
+GRAVE ROBBERS (2)
 Gorex, the Tombshell
 Doomed Necromancer
 Revoke Demise

--- a/etc/J25/GRAVE ROBBERS (3).txt
+++ b/etc/J25/GRAVE ROBBERS (3).txt
@@ -1,3 +1,4 @@
+GRAVE ROBBERS (3)
 Isareth the Awakener
 Revoke Demise
 Eternal Taskmaster

--- a/etc/J25/GRAVE ROBBERS (4).txt
+++ b/etc/J25/GRAVE ROBBERS (4).txt
@@ -1,3 +1,4 @@
+GRAVE ROBBERS (4)
 Isareth the Awakener
 Liliana, Death's Majesty
 Revoke Demise

--- a/etc/J25/HEALERS (1).txt
+++ b/etc/J25/HEALERS (1).txt
@@ -1,3 +1,4 @@
+HEALERS (1)
 Speaker of the Heavens
 Hinterland Sanctifier
 Qala, Ajani's Pridemate

--- a/etc/J25/HEALERS (2).txt
+++ b/etc/J25/HEALERS (2).txt
@@ -1,3 +1,4 @@
+HEALERS (2)
 Valkyrie Harbinger
 Hinterland Sanctifier
 Qala, Ajani's Pridemate

--- a/etc/J25/HEALERS (3).txt
+++ b/etc/J25/HEALERS (3).txt
@@ -1,3 +1,4 @@
+HEALERS (3)
 Righteous Valkyrie
 Hinterland Sanctifier
 Qala, Ajani's Pridemate

--- a/etc/J25/HEALERS (4).txt
+++ b/etc/J25/HEALERS (4).txt
@@ -1,3 +1,4 @@
+HEALERS (4)
 Felidar Sovereign
 Rhox Faithmender
 Hinterland Sanctifier

--- a/etc/J25/HEROES (1).txt
+++ b/etc/J25/HEROES (1).txt
@@ -1,3 +1,4 @@
+HEROES (1)
 Brigone, Soldier of Meletis
 Faithful Pikemaster
 Dauntless Onslaught

--- a/etc/J25/HEROES (2).txt
+++ b/etc/J25/HEROES (2).txt
@@ -1,3 +1,4 @@
+HEROES (2)
 Brigone, Soldier of Meletis
 Ojutai Exemplars
 Faithful Pikemaster

--- a/etc/J25/ICKY (1).txt
+++ b/etc/J25/ICKY (1).txt
@@ -1,3 +1,4 @@
+ICKY (1)
 Fumulus, the Infestation
 Wriggling Grub
 Eaten Alive

--- a/etc/J25/ICKY (2).txt
+++ b/etc/J25/ICKY (2).txt
@@ -1,3 +1,4 @@
+ICKY (2)
 Fumulus, the Infestation
 Endless Cockroaches
 Wriggling Grub

--- a/etc/J25/ILLUSIONS.txt
+++ b/etc/J25/ILLUSIONS.txt
@@ -1,3 +1,4 @@
+ILLUSIONS
 Pol Jamaar, Illusionist
 Lord of the Unreal
 Phantasmal Shieldback

--- a/etc/J25/INVENTIVE (1).txt
+++ b/etc/J25/INVENTIVE (1).txt
@@ -1,3 +1,4 @@
+INVENTIVE (1)
 Sai, Master Thopterist
 Gilded Scuttler
 Ornithopter of Paradise

--- a/etc/J25/INVENTIVE (2).txt
+++ b/etc/J25/INVENTIVE (2).txt
@@ -1,3 +1,4 @@
+INVENTIVE (2)
 Sai, Master Thopterist
 Shimmer Dragon
 Gilded Scuttler

--- a/etc/J25/INVENTIVE (3).txt
+++ b/etc/J25/INVENTIVE (3).txt
@@ -1,3 +1,4 @@
+INVENTIVE (3)
 Padeem, Consul of Innovation
 Thought Monitor
 Gilded Scuttler

--- a/etc/J25/INVENTIVE (4).txt
+++ b/etc/J25/INVENTIVE (4).txt
@@ -1,3 +1,4 @@
+INVENTIVE (4)
 Padeem, Consul of Innovation
 Gilded Scuttler
 Shardless Outlander

--- a/etc/J25/LANDFALL (1).txt
+++ b/etc/J25/LANDFALL (1).txt
@@ -1,3 +1,4 @@
+LANDFALL (1)
 Lotus Cobra
 Undergrowth Champion
 Sutina, Speaker of the Tajuru

--- a/etc/J25/LANDFALL (2).txt
+++ b/etc/J25/LANDFALL (2).txt
@@ -1,3 +1,4 @@
+LANDFALL (2)
 Ancient Greenwarden
 Sutina, Speaker of the Tajuru
 Bite Down

--- a/etc/J25/LANDFALL (3).txt
+++ b/etc/J25/LANDFALL (3).txt
@@ -1,3 +1,4 @@
+LANDFALL (3)
 Scythecat Cub
 Sutina, Speaker of the Tajuru
 Bite Down

--- a/etc/J25/LANDFALL (4).txt
+++ b/etc/J25/LANDFALL (4).txt
@@ -1,3 +1,4 @@
+LANDFALL (4)
 Scythecat Cub
 Sutina, Speaker of the Tajuru
 Baloth Woodcrasher

--- a/etc/J25/LEGION (1).txt
+++ b/etc/J25/LEGION (1).txt
@@ -1,3 +1,4 @@
+LEGION (1)
 Adeline, Resplendent Cathar
 Dawnwing Marshal
 Hinterland Sanctifier

--- a/etc/J25/LEGION (2).txt
+++ b/etc/J25/LEGION (2).txt
@@ -1,3 +1,4 @@
+LEGION (2)
 Adeline, Resplendent Cathar
 Venerated Loxodon
 Dawnwing Marshal

--- a/etc/J25/MODIFIED.txt
+++ b/etc/J25/MODIFIED.txt
@@ -1,3 +1,4 @@
+MODIFIED
 Kodama of the West Tree
 Saurian Symbiote
 Shardless Outlander

--- a/etc/J25/NEFARIOUS.txt
+++ b/etc/J25/NEFARIOUS.txt
@@ -1,3 +1,4 @@
+NEFARIOUS
 Vilis, Broker of Blood
 Dark Confidant
 Scourge of the Undercity

--- a/etc/J25/NER-DO-WELLS (1).txt
+++ b/etc/J25/NER-DO-WELLS (1).txt
@@ -1,3 +1,4 @@
+NER-DO-WELLS (1)
 Rev, Tithe Extractor
 Serpent Assassin
 Thieves' Tools

--- a/etc/J25/NER-DO-WELLS (2).txt
+++ b/etc/J25/NER-DO-WELLS (2).txt
@@ -1,3 +1,4 @@
+NER-DO-WELLS (2)
 Rev, Tithe Extractor
 Thieves' Guild Enforcer
 Grim Bounty

--- a/etc/J25/NINJAS.txt
+++ b/etc/J25/NINJAS.txt
@@ -1,3 +1,4 @@
+NINJAS
 Taeko, the Patient Avalanche
 Starlight Snare
 Ninja of the Deep Hours

--- a/etc/J25/OF THE COAST (1).txt
+++ b/etc/J25/OF THE COAST (1).txt
@@ -1,3 +1,4 @@
+OF THE COAST (1)
 Plagon, Lord of the Beach
 Delightful Discovery
 Gilded Scuttler

--- a/etc/J25/OF THE COAST (2).txt
+++ b/etc/J25/OF THE COAST (2).txt
@@ -1,3 +1,4 @@
+OF THE COAST (2)
 Plagon, Lord of the Beach
 Delightful Discovery
 Gilded Scuttler

--- a/etc/J25/PRIDEFUL.txt
+++ b/etc/J25/PRIDEFUL.txt
@@ -1,3 +1,4 @@
+PRIDEFUL
 Brimaz, King of Oreskos
 Dawnwing Marshal
 Leonin Scimitar

--- a/etc/J25/SNAKES.txt
+++ b/etc/J25/SNAKES.txt
@@ -1,3 +1,4 @@
+SNAKES
 Aphelia, Viper Whisperer
 Hooded Blightfang
 Scourge of the Undercity

--- a/etc/J25/SOARING (1).txt
+++ b/etc/J25/SOARING (1).txt
@@ -1,3 +1,4 @@
+SOARING (1)
 Windreader Sphinx
 Starlight Snare
 Cynette, Jelly Drover

--- a/etc/J25/SOARING (2).txt
+++ b/etc/J25/SOARING (2).txt
@@ -1,3 +1,4 @@
+SOARING (2)
 Cavalier of Gales
 Starlight Snare
 Cynette, Jelly Drover

--- a/etc/J25/SOARING (3).txt
+++ b/etc/J25/SOARING (3).txt
@@ -1,3 +1,4 @@
+SOARING (3)
 Mu Yanling, Sky Dancer
 Starlight Snare
 Cynette, Jelly Drover

--- a/etc/J25/SOARING (4).txt
+++ b/etc/J25/SOARING (4).txt
@@ -1,3 +1,4 @@
+SOARING (4)
 Sprite Noble
 Stolen by the Fae
 Starlight Snare

--- a/etc/J25/STALWART (1).txt
+++ b/etc/J25/STALWART (1).txt
@@ -1,3 +1,4 @@
+STALWART (1)
 Generous Pup
 Ajani, Adversary of Tyrants
 Urdnan, Dromoka Warrior

--- a/etc/J25/STALWART (2).txt
+++ b/etc/J25/STALWART (2).txt
@@ -1,3 +1,4 @@
+STALWART (2)
 Basri's Lieutenant
 Urdnan, Dromoka Warrior
 Banishing Light

--- a/etc/J25/STALWART (3).txt
+++ b/etc/J25/STALWART (3).txt
@@ -1,3 +1,4 @@
+STALWART (3)
 Generous Pup
 Urdnan, Dromoka Warrior
 Banishing Light

--- a/etc/J25/STALWART (4).txt
+++ b/etc/J25/STALWART (4).txt
@@ -1,3 +1,4 @@
+STALWART (4)
 Light of the Legion
 Mikaeus, the Lunarch
 Urdnan, Dromoka Warrior

--- a/etc/J25/STOKED (1).txt
+++ b/etc/J25/STOKED (1).txt
@@ -1,3 +1,4 @@
+STOKED (1)
 Frontline Heroism
 Hearts on Fire
 Scholar of Combustion

--- a/etc/J25/STOKED (2).txt
+++ b/etc/J25/STOKED (2).txt
@@ -1,3 +1,4 @@
+STOKED (2)
 Dreadhorde Arcanist
 Hearts on Fire
 Cleon, Merry Champion

--- a/etc/J25/STOKED (3).txt
+++ b/etc/J25/STOKED (3).txt
@@ -1,3 +1,4 @@
+STOKED (3)
 Frontline Heroism
 Mirrorwing Dragon
 Hearts on Fire

--- a/etc/J25/STOKED (4).txt
+++ b/etc/J25/STOKED (4).txt
@@ -1,3 +1,4 @@
+STOKED (4)
 Goblin Dark-Dwellers
 Hearts on Fire
 Cleon, Merry Champion

--- a/etc/J25/SURPRISE! (1).txt
+++ b/etc/J25/SURPRISE! (1).txt
@@ -1,3 +1,4 @@
+SURPRISE! (1)
 Thryx, the Sudden Storm
 Delightful Discovery
 Brineborn Cutthroat

--- a/etc/J25/SURPRISE! (2).txt
+++ b/etc/J25/SURPRISE! (2).txt
@@ -1,3 +1,4 @@
+SURPRISE! (2)
 Thryx, the Sudden Storm
 Voracious Greatshark
 Delightful Discovery

--- a/etc/J25/SURPRISE! (3).txt
+++ b/etc/J25/SURPRISE! (3).txt
@@ -1,3 +1,4 @@
+SURPRISE! (3)
 Venser, Shaper Savant
 Starlight Snare
 Breaching Hippocamp

--- a/etc/J25/SURPRISE! (4).txt
+++ b/etc/J25/SURPRISE! (4).txt
@@ -1,3 +1,4 @@
+SURPRISE! (4)
 Venser, Shaper Savant
 Wavebreak Hippocamp
 Starlight Snare

--- a/etc/J25/TOO MANY.txt
+++ b/etc/J25/TOO MANY.txt
@@ -1,3 +1,4 @@
+TOO MANY
 Fiendish Duo
 Goblin Surprise
 2 Brothers Yamazaki

--- a/etc/J25/TREASURES (1).txt
+++ b/etc/J25/TREASURES (1).txt
@@ -1,3 +1,4 @@
+TREASURES (1)
 Evereth, Viceroy of Plunder
 Ruthless Technomancer
 Deadly Dispute

--- a/etc/J25/TREASURES (2).txt
+++ b/etc/J25/TREASURES (2).txt
@@ -1,3 +1,4 @@
+TREASURES (2)
 Evereth, Viceroy of Plunder
 Deadly Dispute
 Shambling Ghast

--- a/etc/J25/VAMPIRES (1).txt
+++ b/etc/J25/VAMPIRES (1).txt
@@ -1,3 +1,4 @@
+VAMPIRES (1)
 Sangromancer
 Scourge of the Undercity
 Nazar, the Velvet Fang

--- a/etc/J25/VAMPIRES (2).txt
+++ b/etc/J25/VAMPIRES (2).txt
@@ -1,3 +1,4 @@
+VAMPIRES (2)
 Crossway Troublemakers
 Sanctum Seeker
 Scourge of the Undercity

--- a/etc/J25/VAMPIRES (3).txt
+++ b/etc/J25/VAMPIRES (3).txt
@@ -1,3 +1,4 @@
+VAMPIRES (3)
 Necropolis Regent
 Scourge of the Undercity
 Nazar, the Velvet Fang

--- a/etc/J25/VAMPIRES (4).txt
+++ b/etc/J25/VAMPIRES (4).txt
@@ -1,3 +1,4 @@
+VAMPIRES (4)
 Rodolf Duskbringer
 Scourge of the Undercity
 Nazar, the Velvet Fang

--- a/etc/J25/WARRIORS (1).txt
+++ b/etc/J25/WARRIORS (1).txt
@@ -1,3 +1,4 @@
+WARRIORS (1)
 Gornog, the Red Reaper
 Ghitu Encampment
 Boggart Brute

--- a/etc/J25/WARRIORS (2).txt
+++ b/etc/J25/WARRIORS (2).txt
@@ -1,3 +1,4 @@
+WARRIORS (2)
 Gornog, the Red Reaper
 Kargan Intimidator
 Ghitu Encampment

--- a/etc/J25/WIZARDS (1).txt
+++ b/etc/J25/WIZARDS (1).txt
@@ -1,3 +1,4 @@
+WIZARDS (1)
 Naban, Dean of Iteration
 Starlight Snare
 Faerie Seer

--- a/etc/J25/WIZARDS (2).txt
+++ b/etc/J25/WIZARDS (2).txt
@@ -1,3 +1,4 @@
+WIZARDS (2)
 Naban, Dean of Iteration
 Aether Channeler
 Starlight Snare

--- a/etc/J25/ZEALOTS (1).txt
+++ b/etc/J25/ZEALOTS (1).txt
@@ -1,3 +1,4 @@
+ZEALOTS (1)
 Zealous Conscripts
 Anep, Vizier of Hazoret
 Ahn-Crop Crasher

--- a/etc/J25/ZEALOTS (2).txt
+++ b/etc/J25/ZEALOTS (2).txt
@@ -1,3 +1,4 @@
+ZEALOTS (2)
 Sandstorm Crasher
 Anep, Vizier of Hazoret
 Ahn-Crop Crasher

--- a/etc/J25/ZEALOTS (3).txt
+++ b/etc/J25/ZEALOTS (3).txt
@@ -1,3 +1,4 @@
+ZEALOTS (3)
 Combat Celebrant
 Hearts on Fire
 Anep, Vizier of Hazoret

--- a/etc/J25/ZEALOTS (4).txt
+++ b/etc/J25/ZEALOTS (4).txt
@@ -1,3 +1,4 @@
+ZEALOTS (4)
 Sandstorm Crasher
 Zealous Conscripts
 Anep, Vizier of Hazoret

--- a/etc/parsing-scripts/batch_reformat.py
+++ b/etc/parsing-scripts/batch_reformat.py
@@ -181,7 +181,12 @@ def reformat_deck(input_file: Path, dry_run: bool = False) -> bool:
     # Parse cards
     cards_by_type = defaultdict(list)
 
-    for line in lines:
+    # Skip first line if it matches the deck name (already formatted files)
+    start_line = 0
+    if lines and lines[0].strip() == deck_name:
+        start_line = 1
+
+    for line in lines[start_line:]:
         quantity, card_name, suffix = parse_card_line(line)
 
         if not card_name:

--- a/etc/parsing-scripts/parse_j25.py
+++ b/etc/parsing-scripts/parse_j25.py
@@ -74,6 +74,9 @@ for deck_title, deck_content in decks:
     # Write deck list file
     filepath = os.path.join(output_dir, f'{filename}.txt')
     with open(filepath, 'w') as f:
+        # First line: deck name (matches filename)
+        f.write(filename + '\n')
+        # Then the card list
         for line in lines:
             f.write(line + '\n')
 


### PR DESCRIPTION
## Overview
This PR fixes the J25 deck list format to match the JMP/J22 standard and improves the batch reformatter to be idempotent and smarter about deck names.

## Changes

### 1. Fix J25 Deck Lists - Add Deck Name as First Line
**Problem:** J25 deck files were missing the deck name on the first line, which doesn't match the JMP/J22 standard format.

**Before:**

Brimaz, King of Oreskos Dawnwing Marshal Leonin Scimitar ...


**After:**

PRIDEFUL Brimaz, King of Oreskos Dawnwing Marshal Leonin Scimitar ...


**Changes:**
- Updated `parse_j25.py` to write deck name as first line (derived from filename)
- Regenerated all 121 J25 deck files with proper format
- First line now matches JMP/J22 standard: deck name = filename stem

### 2. Improve Batch Reformatter - Skip Deck Name Line
**Problem:** The batch reformatter would try to parse the deck name as a card when run on already-formatted files.

**Enhancement:** 
- Batch reformatter now skips the first line if it matches the deck name
- Prevents looking up "PRIDEFUL" as a card in Scryfall API
- Makes the script idempotent - safe to run multiple times on same files

**Behavior:**
- First line is always set to deck name (from filename)
- If input already has deck name on line 1, skip it during parsing
- Only actual cards are queried against Scryfall API

## Files Changed
**123 files changed, 130 insertions(+), 1 deletion(-)**

## Commits
1. `d3a4c08` - Improve batch reformatter - skip deck name line when parsing
2. `16942aa` - Fix J25 deck lists - add deck name as first line

## Benefits
- ✅ J25 files now match JMP/J22 standard format
- ✅ Batch reformatter is more intelligent and efficient
- ✅ Safe to run reformatter multiple times (idempotent)
- ✅ No wasted Scryfall API calls on deck names

## Testing
- ✅ All 121 J25 files regenerated with deck name on line 1
- ✅ Verified format matches JMP/J22 standard (`PRIDEFUL.txt` → first line: `PRIDEFUL`)
- ✅ Batch reformatter correctly skips existing deck name lines

## Compatibility
These changes maintain backward compatibility:
- Files without deck names will have them added
- Files with deck names won't have duplicates
- No breaking changes to file structure

##Branch Information
Source branch: claude/general-work-01MpPtsvPGEs2c3hVQx27Btn
Target branch: main