### PR TITLE
Fix batch reformatter - skip card type header lines

### DIFF
--- a/etc/parsing-scripts/batch_reformat.py
+++ b/etc/parsing-scripts/batch_reformat.py
@@ -187,6 +187,10 @@ def reformat_deck(input_file: Path, dry_run: bool = False) -> bool:
         start_line = 1
 
     for line in lines[start_line:]:
+        # Skip comment lines (card type headers like //Creatures (X))
+        if line.strip().startswith('//'):
+            continue
+
         quantity, card_name, suffix = parse_card_line(line)
 
         if not card_name:


### PR DESCRIPTION
## Bug Fix
The reformatter was trying to parse card type headers (//Creatures, //Lands, etc.) as card names and query them in Scryfall API.

## Problem
When running on already-formatted files, lines like:
- `//Creatures (7)`
- `//Lands (2)`
- `//Instants (3)`

Were being passed to Scryfall API as card lookups, causing errors and wasted API calls.

## Solution
Skip any lines starting with `//` before parsing cards.

## Behavior
- Comment/header lines are now ignored
- Only actual card lines are parsed and queried
- Safe to run on both formatted and unformatted files
- Truly idempotent now