### PR TITLE
Fix LTR placeholder card categorization

### DIFF
--- a/etc/LTR/COURAGEOUS 1.txt
+++ b/etc/LTR/COURAGEOUS 1.txt
@@ -15,5 +15,5 @@ COURAGEOUS 1
 1 Fog on the Barrow-Downs
 //Lands (8)
 8 Plains
-//Unknown
+//Special
 1 Rare or mythic rare

--- a/etc/LTR/COURAGEOUS 2.txt
+++ b/etc/LTR/COURAGEOUS 2.txt
@@ -14,5 +14,5 @@ COURAGEOUS 2
 1 Escape from Orthanc
 //Lands (8)
 8 Plains
-//Unknown
+//Special
 1 Rare or mythic rare

--- a/etc/LTR/CUNNING 1.txt
+++ b/etc/LTR/CUNNING 1.txt
@@ -16,5 +16,5 @@ CUNNING 1
 1 The Bath Song
 //Lands (8)
 8 Island
-//Unknown
+//Special
 1 Rare or mythic rare

--- a/etc/LTR/CUNNING 2.txt
+++ b/etc/LTR/CUNNING 2.txt
@@ -17,5 +17,5 @@ CUNNING 2
 1 Bewitching Leechcraft
 //Lands (8)
 8 Island
-//Unknown
+//Special
 1 Rare or mythic rare

--- a/etc/LTR/ELVEN 1.txt
+++ b/etc/LTR/ELVEN 1.txt
@@ -15,5 +15,5 @@ ELVEN 1
 1 Lembas
 //Lands (8)
 8 Forest
-//Unknown
+//Special
 1 Rare or mythic rare

--- a/etc/parsing-scripts/batch_reformat.py
+++ b/etc/parsing-scripts/batch_reformat.py
@@ -244,7 +244,8 @@ def get_card_data(card_name: str) -> Dict:
         return card_cache[card_name]
 
     # Skip special placeholder cards
-    if "Random" in card_name and "rare" in card_name.lower():
+    # Matches: "Random white rare or mythic rare", "Rare or mythic rare", etc.
+    if "rare" in card_name.lower() and ("Random" in card_name or card_name.startswith("Rare")):
         card_data = {"type": "Special"}
         card_cache[card_name] = card_data
         return card_data

--- a/etc/parsing-scripts/batch_reformat.py
+++ b/etc/parsing-scripts/batch_reformat.py
@@ -245,7 +245,8 @@ def get_card_data(card_name: str) -> Dict:
 
     # Skip special placeholder cards
     # Matches: "Random white rare or mythic rare", "Rare or mythic rare", etc.
-    if "rare" in card_name.lower() and ("Random" in card_name or card_name.startswith("Rare")):
+    card_lower = card_name.lower()
+    if ("rare" in card_lower and "mythic" in card_lower) or ("rare" in card_lower and "random" in card_lower):
         card_data = {"type": "Special"}
         card_cache[card_name] = card_data
         return card_data

--- a/etc/parsing-scripts/card_type_cache.json
+++ b/etc/parsing-scripts/card_type_cache.json
@@ -21637,7 +21637,7 @@
     "rarity": "uncommon"
   },
   "Rare or mythic rare": {
-    "type": "Unknown"
+    "type": "Special"
   },
   "Rattlechains": {
     "type": "Creatures",


### PR DESCRIPTION
Changes:

Updated batch_reformat.py special card detection to handle both placeholder formats:
"Random [color] rare or mythic rare" (BRO, DMU, most sets)
"Rare or mythic rare" (LTR)
Improved detection logic: (rare AND mythic) OR (rare AND random)
Impact:

LTR decks (20/20): "Rare or mythic rare" now correctly categorized under //Special instead of //Unknown
More robust placeholder detection across all sets
Files Modified:

etc/parsing-scripts/batch_reformat.py - Enhanced special card detection
etc/LTR/*.txt - All 20 LTR decks reformatted