### PR TITLE
Update combined JSON with tokens field and fixed TLA deck names

### DIFF
--- a/etc/jumpstart-decks-combined.json
+++ b/etc/jumpstart-decks-combined.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0",
-    "generated": "2025-12-04T22:17:15.625476+00:00",
+    "generated": "2026-03-29T23:25:19.724393+00:00",
     "total_decks": 529,
     "total_unique_cards": 2889,
     "sets": [
@@ -52,6 +52,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ABOVE THE CLOUDS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -242,6 +243,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ABOVE THE CLOUDS (2)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -351,7 +363,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -444,6 +467,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ABOVE THE CLOUDS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -634,6 +658,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ABOVE THE CLOUDS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -824,6 +849,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ANGELS (1)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Human",
+          "type_line": "Token Creature — Human",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -879,7 +924,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Human",
+              "type_line": "Token Creature — Human",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -945,7 +1001,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -1010,6 +1077,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ANGELS (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -1143,7 +1221,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -1196,6 +1285,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ARCHAEOLOGY (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -1370,6 +1460,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ARCHAEOLOGY (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -1544,6 +1635,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ARCHAEOLOGY (3)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -1557,7 +1659,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -1720,6 +1833,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ARCHAEOLOGY (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -1892,6 +2006,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "BASRI",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -1904,7 +2038,18 @@
             "W"
           ],
           "rarity": "mythic",
-          "loyalty": "3"
+          "loyalty": "3",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -1946,7 +2091,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -2078,6 +2234,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "CATS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -2270,6 +2427,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "CATS (2)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -2311,7 +2479,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -2460,6 +2639,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "CHANDRA",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -2500,7 +2690,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -2632,6 +2833,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DEVILISH (1)",
+      "tokens": [
+        {
+          "name": "Devil",
+          "type_line": "Token Creature — Devil",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -2659,7 +2871,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Devil",
+              "type_line": "Token Creature — Devil",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -2767,7 +2990,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Devil",
+              "type_line": "Token Creature — Devil",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -2824,6 +3058,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DEVILISH (2)",
+      "tokens": [
+        {
+          "name": "Devil",
+          "type_line": "Token Creature — Devil",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -2851,7 +3096,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Devil",
+              "type_line": "Token Creature — Devil",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -3004,6 +3260,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DEVILISH (3)",
+      "tokens": [
+        {
+          "name": "Devil",
+          "type_line": "Token Creature — Devil",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -3149,7 +3416,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Devil",
+              "type_line": "Token Creature — Devil",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -3194,6 +3472,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DEVILISH (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -3384,6 +3663,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DINOSAURS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -3574,6 +3854,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DINOSAURS (2)",
+      "tokens": [
+        {
+          "name": "Dinosaur",
+          "type_line": "Token Creature — Dinosaur",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -3615,7 +3906,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Dinosaur",
+              "type_line": "Token Creature — Dinosaur",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -3764,6 +4066,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DINOSAURS (3)",
+      "tokens": [
+        {
+          "name": "Dinosaur",
+          "type_line": "Token Creature — Dinosaur",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -3805,7 +4118,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Dinosaur",
+              "type_line": "Token Creature — Dinosaur",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -3954,6 +4278,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DINOSAURS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -4144,6 +4469,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DISCARDING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -4319,6 +4645,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DISCARDING (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -4332,7 +4669,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4496,6 +4844,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOCTOR (1)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Griffin",
+          "type_line": "Token Creature — Griffin",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -4551,7 +4919,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4639,7 +5018,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Griffin",
+              "type_line": "Token Creature — Griffin",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4684,6 +5074,35 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOCTOR (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Griffin",
+          "type_line": "Token Creature — Griffin",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -4739,7 +5158,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4779,7 +5209,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4827,7 +5268,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Griffin",
+              "type_line": "Token Creature — Griffin",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -4872,6 +5324,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOCTOR (3)",
+      "tokens": [
+        {
+          "name": "Griffin",
+          "type_line": "Token Creature — Griffin",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5003,7 +5466,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Griffin",
+              "type_line": "Token Creature — Griffin",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5060,6 +5534,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOCTOR (4)",
+      "tokens": [
+        {
+          "name": "Griffin",
+          "type_line": "Token Creature — Griffin",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5217,7 +5702,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Griffin",
+              "type_line": "Token Creature — Griffin",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5250,6 +5746,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOGS (1)",
+      "tokens": [
+        {
+          "name": "Dog",
+          "type_line": "Token Creature — Dog",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5373,7 +5889,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Dog",
+              "type_line": "Token Creature — Dog",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5385,7 +5912,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5442,6 +5980,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DOGS (2)",
+      "tokens": [
+        {
+          "name": "Dog",
+          "type_line": "Token Creature — Dog",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5565,7 +6123,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Dog",
+              "type_line": "Token Creature — Dog",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5577,7 +6146,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5634,6 +6214,22 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DRAGONS (1)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5659,7 +6255,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5753,7 +6356,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5810,6 +6424,31 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "DRAGONS (2)",
+      "tokens": [
+        {
+          "name": "Dragon",
+          "type_line": "Token Creature — Dragon",
+          "colors": [
+            "R"
+          ],
+          "power": "5",
+          "toughness": "5"
+        },
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -5823,7 +6462,18 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5837,7 +6487,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5907,7 +6564,14 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5933,7 +6597,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -5990,6 +6665,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ELVES (1)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -6031,7 +6717,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6149,7 +6846,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6182,6 +6890,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ELVES (2)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -6195,7 +6914,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6341,7 +7071,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6374,6 +7115,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ENCHANTED (1)",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -6481,7 +7233,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6562,6 +7325,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ENCHANTED (2)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -6575,7 +7358,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6681,7 +7475,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6750,6 +7555,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "FEATHERED FRIENDS (1)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -6805,7 +7621,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -6942,6 +7769,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "FEATHERED FRIENDS (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7011,7 +7858,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7077,7 +7935,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7134,6 +8003,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "FEATHERED FRIENDS (3)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7189,7 +8069,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7326,6 +8217,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "FEATHERED FRIENDS (4)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7381,7 +8283,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7518,6 +8431,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "GARRUK",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7530,7 +8454,18 @@
             "G"
           ],
           "rarity": "mythic",
-          "loyalty": "4"
+          "loyalty": "4",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7704,6 +8639,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "GOBLINS (1)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7717,7 +8663,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7787,7 +8744,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7898,6 +8866,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "GOBLINS (2)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -7911,7 +8890,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -7939,7 +8929,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8092,6 +9093,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "GOBLINS (3)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -8133,7 +9145,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8189,7 +9212,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8288,6 +9322,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "GOBLINS (4)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -8301,7 +9346,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8343,7 +9399,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8409,7 +9476,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8478,6 +9556,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "HEAVILY ARMORED (1)",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -8613,7 +9702,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8670,6 +9770,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "HEAVILY ARMORED (2)",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -8805,7 +9916,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -8862,6 +9984,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "HEAVILY ARMORED (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -9056,6 +10179,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "HEAVILY ARMORED (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -9250,6 +10374,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LANDS (1)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -9395,7 +10530,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9440,6 +10586,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LANDS (2)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -9537,7 +10694,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9634,6 +10802,35 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LEGION (1)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -9675,7 +10872,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9689,7 +10897,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9777,7 +10996,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9822,6 +11052,35 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LEGION (2)",
+      "tokens": [
+        {
+          "name": "Dog",
+          "type_line": "Token Creature — Dog",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -9863,7 +11122,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9917,7 +11187,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Dog",
+              "type_line": "Token Creature — Dog",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -9953,7 +11234,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10010,6 +11302,35 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LEGION (3)",
+      "tokens": [
+        {
+          "name": "Dog",
+          "type_line": "Token Creature — Dog",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -10037,7 +11358,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10103,7 +11435,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Dog",
+              "type_line": "Token Creature — Dog",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10139,7 +11482,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10196,6 +11550,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LEGION (4)",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -10209,7 +11583,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10265,7 +11650,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10341,7 +11737,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10386,6 +11793,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LIGHTNING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -10562,6 +11970,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LIGHTNING (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -10738,6 +12147,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "LILIANA",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -10848,7 +12268,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -10926,6 +12357,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MILLING",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -11116,6 +12548,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINIONS (1)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -11129,7 +12572,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11308,6 +12762,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINIONS (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -11377,7 +12842,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11500,6 +12976,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINIONS (3)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -11541,7 +13028,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11583,7 +13081,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11702,6 +13211,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINIONS (4)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -11715,7 +13235,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11743,7 +13274,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11799,7 +13341,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -11894,6 +13447,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINOTAURS (1)",
+      "tokens": [
+        {
+          "name": "Minotaur",
+          "type_line": "Token Creature — Minotaur",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -11921,7 +13485,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Minotaur",
+              "type_line": "Token Creature — Minotaur",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12003,7 +13578,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Minotaur",
+              "type_line": "Token Creature — Minotaur",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12082,6 +13668,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "MINOTAURS (2)",
+      "tokens": [
+        {
+          "name": "Minotaur",
+          "type_line": "Token Creature — Minotaur",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -12109,7 +13706,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Minotaur",
+              "type_line": "Token Creature — Minotaur",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12191,7 +13799,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Minotaur",
+              "type_line": "Token Creature — Minotaur",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12272,6 +13891,15 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PHYREXIAN",
+      "tokens": [
+        {
+          "name": "Phyrexian Myr",
+          "type_line": "Token Artifact Creature — Phyrexian Myr",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -12325,7 +13953,16 @@
           "colors": [],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Phyrexian Myr",
+              "type_line": "Token Artifact Creature — Phyrexian Myr",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12427,7 +14064,16 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Phyrexian Myr",
+              "type_line": "Token Artifact Creature — Phyrexian Myr",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12460,6 +14106,13 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PIRATES (1)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -12487,7 +14140,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12543,7 +14203,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12557,7 +14224,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12648,6 +14322,13 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PIRATES (2)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -12675,7 +14356,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12717,7 +14405,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12745,7 +14440,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -12836,6 +14538,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PLUS ONE (1)",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -12981,7 +14694,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13014,6 +14738,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PLUS ONE (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -13192,6 +14917,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PLUS ONE (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -13370,6 +15096,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PLUS ONE (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -13546,6 +15273,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PREDATORY (1)",
+      "tokens": [
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -13601,7 +15348,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13691,7 +15449,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13734,6 +15503,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PREDATORY (2)",
+      "tokens": [
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -13787,7 +15576,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13877,7 +15677,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13920,6 +15731,35 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PREDATORY (3)",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -13933,7 +15773,18 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -13961,7 +15812,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14063,7 +15925,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14106,6 +15979,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "PREDATORY (4)",
+      "tokens": [
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -14147,7 +16040,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14263,7 +16167,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14296,6 +16211,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "RAINBOW",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -14388,7 +16314,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14543,6 +16480,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "REANIMATED (1)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "5",
+          "toughness": "5"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -14626,7 +16574,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -14735,6 +16694,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "REANIMATED (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -14925,6 +16885,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "REANIMATED (3)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -15082,7 +17053,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -15115,6 +17097,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "REANIMATED (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -15305,6 +17288,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ROGUE (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -15495,6 +17479,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "ROGUES (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -15685,6 +17670,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SEISMIC",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -15871,6 +17857,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SMASHING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -16061,6 +18048,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SMASHING (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -16247,6 +18235,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SMASHING (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -16439,6 +18428,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SMASHING (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -16631,6 +18621,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPELLCASTING (2)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -16644,7 +18645,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -16821,6 +18833,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPELLCASTING (3)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -16944,7 +18967,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -17013,6 +19047,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPELLCASTING (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -17201,6 +19236,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPELLINGCASTING (1)",
+      "tokens": [
+        {
+          "name": "Goblin Wizard",
+          "type_line": "Token Creature — Goblin Wizard",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -17320,7 +19366,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin Wizard",
+              "type_line": "Token Creature — Goblin Wizard",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -17389,6 +19446,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPIRITS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -17579,6 +19637,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPIRITS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -17769,6 +19828,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPOOKY (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -17961,6 +20021,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPOOKY (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -18153,6 +20214,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPOOKY (3)",
+      "tokens": [
+        {
+          "name": "Rat",
+          "type_line": "Token Creature — Rat",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -18166,7 +20247,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Rat",
+              "type_line": "Token Creature — Rat",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -18236,7 +20328,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -18347,6 +20450,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "SPOOKY (4)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -18444,7 +20558,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -18541,6 +20666,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "TEFERI",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -18635,7 +20771,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -18723,6 +20870,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "TREE-HUGGING (1)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -18764,7 +20922,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -18915,6 +21084,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "TREE-HUGGING (2)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -18956,7 +21136,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19107,6 +21298,26 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "TREE-HUGGING (3)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -19134,7 +21345,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19148,7 +21370,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19299,6 +21532,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "TREE-HUGGING (4)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -19456,7 +21700,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19489,6 +21744,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "UNDER THE SEA (1)",
+      "tokens": [
+        {
+          "name": "Pirate",
+          "type_line": "Token Creature — Pirate",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -19558,7 +21824,18 @@
           ],
           "rarity": "rare",
           "power": "8",
-          "toughness": "8"
+          "toughness": "8",
+          "tokens": [
+            {
+              "name": "Pirate",
+              "type_line": "Token Creature — Pirate",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19665,6 +21942,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "UNDER THE SEA (2)",
+      "tokens": [
+        {
+          "name": "Pirate",
+          "type_line": "Token Creature — Pirate",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -19748,7 +22036,18 @@
           ],
           "rarity": "rare",
           "power": "8",
-          "toughness": "8"
+          "toughness": "8",
+          "tokens": [
+            {
+              "name": "Pirate",
+              "type_line": "Token Creature — Pirate",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -19841,6 +22140,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "UNICORNS",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -19924,7 +22234,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -20031,6 +22352,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "VAMPIRES (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -20223,6 +22545,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "VAMPIRES (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -20415,6 +22738,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "VAMPIRES (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -20607,6 +22931,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "VAMPIRES (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -20799,6 +23124,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WALLS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -20987,6 +23313,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WELL-READ (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -21175,6 +23502,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WELL-READ (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -21361,6 +23689,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WELL-READ (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -21549,6 +23878,7 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WELL-READ (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -21737,6 +24067,13 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WITCHCRAFT (1)",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -21792,7 +24129,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -21846,7 +24190,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -21913,6 +24264,13 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WITCHCRAFT (2)",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -21926,7 +24284,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22034,7 +24399,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22089,6 +24461,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WIZARDS (1)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -22102,7 +24485,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22170,7 +24564,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22275,6 +24680,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WIZARDS (2)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -22370,7 +24786,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22473,6 +24900,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WIZARDS (3)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -22486,7 +24924,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22554,7 +25003,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22659,6 +25119,17 @@
       "set": "JMP",
       "set_name": "JumpStart 2020",
       "deck_name": "WIZARDS (4)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -22754,7 +25225,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22847,6 +25329,27 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BLINK (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -22888,7 +25391,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22930,7 +25440,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -22944,7 +25461,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23034,6 +25562,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BLINK (2)",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23131,7 +25670,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23221,6 +25771,22 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BLINK (3)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23248,7 +25814,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23318,7 +25891,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23408,6 +25992,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BLINK (4)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23503,7 +26098,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23591,6 +26197,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BONEYARD (1)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23604,7 +26221,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23780,6 +26408,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "BONEYARD (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23807,7 +26446,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -23969,6 +26619,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CATS (1)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -23982,7 +26643,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -24154,6 +26826,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CATS (2)",
+      "tokens": [
+        {
+          "name": "Cat Beast",
+          "type_line": "Token Creature — Cat Beast",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -24301,7 +26984,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Cat Beast",
+              "type_line": "Token Creature — Cat Beast",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -24341,6 +27035,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CATS (3)",
+      "tokens": [
+        {
+          "name": "Ajani's Pridemate",
+          "type_line": "Token Creature — Cat Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -24497,7 +27202,18 @@
             "W"
           ],
           "rarity": "mythic",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Ajani's Pridemate",
+              "type_line": "Token Creature — Cat Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -24525,6 +27241,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CATS (4)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -24538,7 +27265,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -24710,6 +27448,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CONSTELLATION (1)",
+      "tokens": [
+        {
+          "name": "Pegasus",
+          "type_line": "Token Creature — Pegasus",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -24723,7 +27472,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Pegasus",
+              "type_line": "Token Creature — Pegasus",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -24897,6 +27657,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CONSTELLATION (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -25006,7 +27777,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -25082,6 +27864,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CRUEL (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -25264,6 +28047,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CRUEL (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -25445,6 +28229,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CRUEL (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -25626,6 +28411,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CRUEL (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -25809,6 +28595,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CYCLING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -26006,6 +28793,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "CYCLING (2)",
+      "tokens": [
+        {
+          "name": "Rat",
+          "type_line": "Token Creature — Rat",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -26033,7 +28831,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Rat",
+              "type_line": "Token Creature — Rat",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26201,6 +29010,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DEMONS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -26386,6 +29196,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DEMONS (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -26413,7 +29234,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26571,6 +29403,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DETECTIVE (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -26608,7 +29452,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26622,7 +29473,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26650,7 +29508,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26676,7 +29541,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26688,7 +29560,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26698,7 +29577,14 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26710,7 +29596,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26722,7 +29615,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26750,6 +29650,13 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DETECTIVE (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -26803,7 +29710,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26845,7 +29759,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26857,7 +29778,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26869,7 +29797,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26889,7 +29824,14 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26901,7 +29843,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26929,6 +29878,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DETECTIVE (3)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -26982,7 +29943,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -26996,7 +29964,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27024,7 +29999,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27050,7 +30032,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27062,7 +30051,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27072,7 +30068,14 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27084,7 +30087,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27112,6 +30122,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DETECTIVE (4)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -27125,7 +30147,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27151,7 +30180,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27165,7 +30201,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27193,7 +30236,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27205,7 +30255,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27217,7 +30274,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27227,7 +30291,14 @@
           "mana_cost": "{5}",
           "cmc": 5.0,
           "colors": [],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27237,7 +30308,14 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27249,7 +30327,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27290,6 +30375,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DRAGONS (1)",
+      "tokens": [
+        {
+          "name": "Dragon",
+          "type_line": "Token Creature — Dragon",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -27317,7 +30422,18 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27399,7 +30515,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27476,6 +30603,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "DRAGONS (2)",
+      "tokens": [
+        {
+          "name": "Dragon",
+          "type_line": "Token Creature — Dragon",
+          "colors": [
+            "R"
+          ],
+          "power": "5",
+          "toughness": "5"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -27489,7 +30627,18 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27661,6 +30810,15 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ELDRAZI",
+      "tokens": [
+        {
+          "name": "Eldrazi Scion",
+          "type_line": "Token Creature — Eldrazi Scion",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -27696,7 +30854,16 @@
           "colors": [],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Eldrazi Scion",
+              "type_line": "Token Creature — Eldrazi Scion",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27708,7 +30875,16 @@
           "colors": [],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Eldrazi Scion",
+              "type_line": "Token Creature — Eldrazi Scion",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27732,7 +30908,16 @@
           "colors": [],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Eldrazi Scion",
+              "type_line": "Token Creature — Eldrazi Scion",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27844,6 +31029,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ELVES (1)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -27857,7 +31053,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27871,7 +31078,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -27955,7 +31173,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28003,7 +31232,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28031,6 +31271,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ELVES (2)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -28044,7 +31295,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28058,7 +31320,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28142,7 +31415,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28190,7 +31474,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28218,6 +31513,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ELVES (3)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -28231,7 +31537,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28259,7 +31576,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28301,7 +31629,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28315,7 +31654,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28363,7 +31713,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28401,6 +31762,22 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ELVES (4)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -28442,7 +31819,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28468,7 +31856,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28496,7 +31891,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28544,7 +31950,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28556,7 +31973,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28584,6 +32012,22 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "EXPERIMENTAL (1)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -28597,7 +32041,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28639,7 +32094,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28705,7 +32167,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "*",
+              "toughness": "*"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28769,6 +32242,13 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "EXPERIMENTAL (2)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -28810,7 +32290,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -28954,6 +32441,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FAERIES (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -29139,6 +32627,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FAERIES (2)",
+      "tokens": [
+        {
+          "name": "Faerie",
+          "type_line": "Token Creature — Faerie",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -29248,7 +32747,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Faerie",
+              "type_line": "Token Creature — Faerie",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -29322,6 +32832,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FANGS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -29509,6 +33020,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FANGS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -29696,6 +33208,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FANGS (3)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "*",
+          "toughness": "*"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -29709,7 +33232,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "*",
+              "toughness": "*"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -29883,6 +33417,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FANGS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -30070,6 +33605,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FEROCIOUS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -30257,6 +33793,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FEROCIOUS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -30444,6 +33981,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FEROCIOUS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -30629,6 +34167,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FEROCIOUS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -30824,6 +34363,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FIERY (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -31010,6 +34550,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FIERY (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -31195,6 +34736,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FIERY (3)",
+      "tokens": [
+        {
+          "name": "Devil",
+          "type_line": "Token Creature — Devil",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -31314,7 +34866,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Devil",
+              "type_line": "Token Creature — Devil",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -31378,6 +34941,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "FIERY (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -31563,6 +35127,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GIGANTIC (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -31750,6 +35315,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GIGANTIC (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -31937,6 +35503,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GO TO SCHOOL (1)",
+      "tokens": [
+        {
+          "name": "Wizard",
+          "type_line": "Token Creature — Wizard",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32097,7 +35674,18 @@
             "U"
           ],
           "rarity": "uncommon",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Wizard",
+              "type_line": "Token Creature — Wizard",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32125,6 +35713,27 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GO TO SCHOOL (2)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R",
+            "U"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Wizard",
+          "type_line": "Token Creature — Wizard",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32232,7 +35841,19 @@
           "colors": [
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R",
+                "U"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32281,7 +35902,18 @@
             "U"
           ],
           "rarity": "uncommon",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Wizard",
+              "type_line": "Token Creature — Wizard",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32309,6 +35941,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GOBLINS (1)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32322,7 +35965,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32418,7 +36072,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32442,7 +36107,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32494,6 +36170,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GOBLINS (2)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32507,7 +36194,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32603,7 +36301,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32627,7 +36336,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32679,6 +36399,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GOBLINS (3)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32800,7 +36531,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32862,6 +36604,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GOBLINS (4)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -32875,7 +36628,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32889,7 +36653,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32957,7 +36732,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32969,7 +36755,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -32993,7 +36790,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -33045,6 +36853,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GROSS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -33240,6 +37049,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GROSS (2)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -33323,7 +37143,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -33375,7 +37206,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -33437,6 +37279,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GROSS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -33622,6 +37465,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "GROSS (4)",
+      "tokens": [
+        {
+          "name": "Snake",
+          "type_line": "Token Creature — Snake",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -33635,7 +37489,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Snake",
+              "type_line": "Token Creature — Snake",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -33811,6 +37676,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "HOLY (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -33996,6 +37862,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "HOLY (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -34183,6 +38050,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "HOLY (3)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -34196,7 +38083,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34326,7 +38224,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34366,6 +38275,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "HOLY (4)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -34421,7 +38341,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34553,6 +38484,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INSECTS (1)",
+      "tokens": [
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -34566,7 +38508,18 @@
           ],
           "rarity": "rare",
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34608,7 +38561,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34714,7 +38678,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34742,6 +38717,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INSECTS (2)",
+      "tokens": [
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -34901,7 +38887,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -34929,6 +38926,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INSECTS (3)",
+      "tokens": [
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -34984,7 +38992,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35090,7 +39109,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35118,6 +39148,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INSECTS (4)",
+      "tokens": [
+        {
+          "name": "Butterfly",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -35229,7 +39279,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Butterfly",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35277,7 +39338,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35305,6 +39377,15 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INVENTIVE (1)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -35318,7 +39399,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35374,7 +39464,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35412,7 +39511,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35467,7 +39575,16 @@
             "U"
           ],
           "rarity": "mythic",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35495,6 +39612,15 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INVENTIVE (2)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -35506,7 +39632,16 @@
           "colors": [],
           "rarity": "rare",
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35520,7 +39655,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35588,7 +39732,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35614,7 +39767,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35684,6 +39846,15 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INVENTIVE (3)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -35709,7 +39880,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35749,7 +39929,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35787,7 +39976,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35809,7 +40007,16 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35841,7 +40048,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35869,6 +40085,20 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "INVENTIVE (4)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -35894,7 +40124,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35906,7 +40145,14 @@
           "colors": [],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35918,7 +40164,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35946,7 +40199,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -35996,7 +40258,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -36066,6 +40337,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "KNIGHTS",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -36175,7 +40457,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -36247,6 +40540,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LANDFALL (1)",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -36302,7 +40615,18 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -36390,7 +40714,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -36440,6 +40775,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LANDFALL (2)",
+      "tokens": [
+        {
+          "name": "Plant",
+          "type_line": "Token Creature — Plant",
+          "colors": [
+            "G"
+          ],
+          "power": "0",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -36509,7 +40855,18 @@
           ],
           "rarity": "mythic",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Plant",
+              "type_line": "Token Creature — Plant",
+              "colors": [
+                "G"
+              ],
+              "power": "0",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -36637,6 +40994,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LAW (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -36824,6 +41182,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LAW (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -36933,7 +41311,27 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            },
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -37009,6 +41407,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LAW (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -37195,6 +41594,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "LAW (4)",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -37352,7 +41762,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -37380,6 +41801,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MERFOLK (1)",
+      "tokens": [
+        {
+          "name": "Merfolk",
+          "type_line": "Token Creature — Merfolk",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -37527,7 +41959,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Merfolk",
+              "type_line": "Token Creature — Merfolk",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -37567,6 +42010,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MERFOLK (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -37754,6 +42198,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MERFOLK (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -37941,6 +42386,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MERFOLK (4)",
+      "tokens": [
+        {
+          "name": "Merfolk",
+          "type_line": "Token Creature — Merfolk",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -38088,7 +42544,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Merfolk",
+              "type_line": "Token Creature — Merfolk",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38128,6 +42595,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MORBID (1)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -38155,7 +42633,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38169,7 +42658,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38323,6 +42823,26 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MORBID (2)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "5",
+          "toughness": "5"
+        },
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -38350,7 +42870,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38364,7 +42895,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38378,7 +42920,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38392,7 +42945,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -38520,6 +43084,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MULTI-HEADED (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -38703,6 +43268,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "MULTI-HEADED (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -38888,6 +43454,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "PRIMATES",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -39083,6 +43650,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "RAID (1)",
+      "tokens": [
+        {
+          "name": "Ragavan",
+          "type_line": "Token Legendary Creature — Monkey",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -39096,7 +43674,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ragavan",
+              "type_line": "Token Legendary Creature — Monkey",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -39270,6 +43859,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "RAID (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -39455,6 +44045,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "RAID (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -39642,6 +44233,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "RAID (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -39829,6 +44421,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "RATS",
+      "tokens": [
+        {
+          "name": "Rat",
+          "type_line": "Token Creature — Rat",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -39870,7 +44473,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Rat",
+              "type_line": "Token Creature — Rat",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -40016,6 +44630,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SCRYING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -40199,6 +44814,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SCRYING (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -40384,6 +45000,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SHAPESHIFTERS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -40565,6 +45182,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SNOW",
+      "tokens": [
+        {
+          "name": "Marit Lage",
+          "type_line": "Token Legendary Creature — Avatar",
+          "colors": [
+            "B"
+          ],
+          "power": "20",
+          "toughness": "20"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -40706,7 +45334,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Marit Lage",
+              "type_line": "Token Legendary Creature — Avatar",
+              "colors": [
+                "B"
+              ],
+              "power": "20",
+              "toughness": "20"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -40746,6 +45385,22 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SPEEDY",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -40787,7 +45442,14 @@
           ],
           "rarity": "mythic",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -40801,7 +45463,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -40935,6 +45608,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SPICY",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -41120,6 +45794,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SPIRITS (1)",
+      "tokens": [
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -41133,7 +45818,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41189,7 +45885,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41243,7 +45950,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41255,7 +45973,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41307,6 +46036,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "SPIRITS (2)",
+      "tokens": [
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -41320,7 +46060,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41348,7 +46099,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41416,7 +46178,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41452,7 +46225,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -41492,6 +46276,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TEAMWORK (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -41687,6 +46472,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TEAMWORK (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -41882,6 +46668,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "THINK AGAIN (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -42080,6 +46867,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "THINK AGAIN (2)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -42093,7 +46891,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42265,6 +47074,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "THINK AGAIN (3)",
+      "tokens": [
+        {
+          "name": "Drake",
+          "type_line": "Token Creature — Drake",
+          "colors": [
+            "U"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -42278,7 +47098,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Drake",
+              "type_line": "Token Creature — Drake",
+              "colors": [
+                "U"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42462,6 +47293,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "THINK AGAIN (4)",
+      "tokens": [
+        {
+          "name": "Faerie",
+          "type_line": "Token Creature — Faerie",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -42475,7 +47317,18 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Faerie",
+              "type_line": "Token Creature — Faerie",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42659,6 +47512,27 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TREASURE (1)",
+      "tokens": [
+        {
+          "name": "Construct",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [
+            "R"
+          ],
+          "power": "3",
+          "toughness": "1"
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -42672,7 +47546,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42686,7 +47567,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Construct",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [
+                "R"
+              ],
+              "power": "3",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42714,7 +47606,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42740,7 +47639,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42754,7 +47660,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42780,7 +47693,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42802,7 +47722,14 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42814,7 +47741,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42842,6 +47776,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TREASURE (2)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -42855,7 +47801,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42897,7 +47850,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42951,7 +47911,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42965,7 +47932,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42977,7 +47951,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -42999,7 +47980,14 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43027,6 +48015,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TREASURE (3)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -43040,7 +48040,14 @@
           ],
           "rarity": "mythic",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43068,7 +48075,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43110,7 +48124,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43122,7 +48143,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43136,7 +48164,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43172,7 +48207,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43182,7 +48224,14 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43210,6 +48259,18 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "TREASURE (4)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -43223,7 +48284,14 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43251,7 +48319,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43291,7 +48366,14 @@
           "colors": [],
           "rarity": "common",
           "power": "0",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43303,7 +48385,14 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43317,7 +48406,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43329,7 +48425,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43351,7 +48454,14 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43363,7 +48473,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43391,6 +48508,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "UNLUCKY THIRTEEN",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -43446,7 +48574,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -43588,6 +48727,15 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "URZA'S",
+      "tokens": [
+        {
+          "name": "Assembly-Worker",
+          "type_line": "Token Artifact Creature — Assembly-Worker",
+          "colors": [],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -43732,7 +48880,16 @@
           "mana_cost": "",
           "cmc": 0.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Assembly-Worker",
+              "type_line": "Token Artifact Creature — Assembly-Worker",
+              "colors": [],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 3,
@@ -43770,6 +48927,7 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "VEHICLES",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -43949,6 +49107,31 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "WOLVES (1)",
+      "tokens": [
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44004,7 +49187,18 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44032,7 +49226,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44058,7 +49259,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44082,7 +49294,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44094,7 +49317,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44107,7 +49341,18 @@
             "G"
           ],
           "rarity": "uncommon",
-          "loyalty": "7"
+          "loyalty": "7",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44135,6 +49380,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "WOLVES (2)",
+      "tokens": [
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44148,7 +49404,18 @@
           ],
           "rarity": "mythic",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44232,7 +49499,18 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44295,7 +49573,18 @@
             "G"
           ],
           "rarity": "uncommon",
-          "loyalty": "7"
+          "loyalty": "7",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44323,6 +49612,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "WOLVES (3)",
+      "tokens": [
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44336,7 +49636,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44378,7 +49689,18 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44430,7 +49752,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44454,7 +49787,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44466,7 +49810,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44479,7 +49834,18 @@
             "G"
           ],
           "rarity": "uncommon",
-          "loyalty": "7"
+          "loyalty": "7",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44507,6 +49873,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "WOLVES (4)",
+      "tokens": [
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44520,7 +49897,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44576,7 +49964,18 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44642,7 +50041,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44667,7 +50077,18 @@
             "G"
           ],
           "rarity": "uncommon",
-          "loyalty": "7"
+          "loyalty": "7",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44695,6 +50116,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ZOMBIES (1)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44764,7 +50196,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44806,7 +50249,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44842,7 +50296,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44882,6 +50347,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ZOMBIES (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -44937,7 +50413,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -44993,7 +50480,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45042,7 +50540,18 @@
             "B"
           ],
           "rarity": "mythic",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45070,6 +50579,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ZOMBIES (3)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -45111,7 +50631,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45167,7 +50698,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45203,7 +50745,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45215,7 +50768,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45255,6 +50819,17 @@
       "set": "J22",
       "set_name": "JumpStart 2022",
       "deck_name": "ZOMBIES (4)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -45296,7 +50871,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45352,7 +50938,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45386,7 +50983,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45398,7 +51006,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45438,6 +51057,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ANGELS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -45619,6 +51239,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ANGELS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -45800,6 +51421,35 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ARMED (1)",
+      "tokens": [
+        {
+          "name": "Angel Warrior",
+          "type_line": "Token Creature — Angel Warrior",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -45915,7 +51565,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45927,7 +51588,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45939,7 +51611,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel Warrior",
+              "type_line": "Token Creature — Angel Warrior",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -45979,6 +51662,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ARMED (2)",
+      "tokens": [
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -46096,7 +51799,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46108,7 +51822,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46120,7 +51845,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46160,6 +51896,35 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ARMED (3)",
+      "tokens": [
+        {
+          "name": "Angel Warrior",
+          "type_line": "Token Creature — Angel Warrior",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -46279,7 +52044,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46291,7 +52067,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46303,7 +52090,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Angel Warrior",
+              "type_line": "Token Creature — Angel Warrior",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46343,6 +52141,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ARMED (4)",
+      "tokens": [
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -46474,7 +52292,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46486,7 +52315,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46526,6 +52366,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BEASTS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -46713,6 +52554,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BEASTS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -46901,6 +52743,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BLOODY (1)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -46928,7 +52777,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46942,7 +52798,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46956,7 +52819,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -46970,7 +52840,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47012,7 +52889,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47088,6 +52972,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BLOODY (2)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -47115,7 +53006,14 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47129,7 +53027,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47157,7 +53062,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47171,7 +53083,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47275,6 +53194,18 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BLOODY (3)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -47288,7 +53219,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47302,7 +53240,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47316,7 +53261,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47330,7 +53282,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47344,7 +53303,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47462,6 +53428,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BLOODY (4)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -47489,7 +53462,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47503,7 +53483,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47517,7 +53504,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47531,7 +53525,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47573,7 +53574,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -47649,6 +53657,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BOOKWORMS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -47834,6 +53843,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BOOKWORMS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -48029,6 +54039,15 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BOOKWORMS (3)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -48126,7 +54145,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -48214,6 +54242,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BOOKWORMS (4)",
+      "tokens": [
+        {
+          "name": "Tentacle",
+          "type_line": "Token Creature — Tentacle",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -48227,7 +54266,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Tentacle",
+              "type_line": "Token Creature — Tentacle",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -48411,6 +54461,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "BURNING",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -48424,7 +54481,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -48598,6 +54662,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "CHAOS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -48825,6 +54890,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "CLERICS (1)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "5",
+          "toughness": "5"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -48880,7 +54956,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49012,6 +55099,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "CLERICS (2)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "5",
+          "toughness": "5"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -49067,7 +55165,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49199,6 +55308,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "CLERICS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -49386,6 +55496,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "CLERICS (4)",
+      "tokens": [
+        {
+          "name": "Demon",
+          "type_line": "Token Creature — Demon",
+          "colors": [
+            "B"
+          ],
+          "power": "5",
+          "toughness": "5"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -49455,7 +55576,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Demon",
+              "type_line": "Token Creature — Demon",
+              "colors": [
+                "B"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49573,6 +55705,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "COPIED (1)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -49670,7 +55813,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49758,6 +55912,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "COPIED (2)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -49855,7 +56020,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49943,6 +56119,36 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DINNER",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Giant",
+          "type_line": "Token Creature — Giant",
+          "colors": [
+            "G"
+          ],
+          "power": "7",
+          "toughness": "7"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -49956,7 +56162,14 @@
           ],
           "rarity": "mythic",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49970,7 +56183,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -49984,7 +56208,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50012,7 +56243,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50026,7 +56264,19 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            },
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50040,7 +56290,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50064,7 +56321,23 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Giant",
+              "type_line": "Token Creature — Giant",
+              "colors": [
+                "G"
+              ],
+              "power": "7",
+              "toughness": "7"
+            },
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50100,7 +56373,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50128,6 +56408,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DINOSAURS (1)",
+      "tokens": [
+        {
+          "name": "Dinosaur",
+          "type_line": "Token Creature — Dinosaur",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -50155,7 +56455,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50239,7 +56550,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Dinosaur",
+              "type_line": "Token Creature — Dinosaur",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50315,6 +56637,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DINOSAURS (2)",
+      "tokens": [
+        {
+          "name": "Dinosaur",
+          "type_line": "Token Creature — Dinosaur",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -50356,7 +56698,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50426,7 +56779,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Dinosaur",
+              "type_line": "Token Creature — Dinosaur",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50502,6 +56866,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DRAGONS (1)",
+      "tokens": [
+        {
+          "name": "Dragon",
+          "type_line": "Token Creature — Dragon",
+          "colors": [
+            "R"
+          ],
+          "power": "5",
+          "toughness": "5"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -50515,7 +56895,18 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50585,7 +56976,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50611,7 +57009,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50685,6 +57090,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DRAGONS (2)",
+      "tokens": [
+        {
+          "name": "Dragon",
+          "type_line": "Token Creature — Dragon",
+          "colors": [
+            "R"
+          ],
+          "power": "5",
+          "toughness": "5"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -50698,7 +57119,18 @@
           ],
           "rarity": "rare",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50794,7 +57226,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50831,7 +57270,18 @@
             "R"
           ],
           "rarity": "mythic",
-          "loyalty": "3"
+          "loyalty": "3",
+          "tokens": [
+            {
+              "name": "Dragon",
+              "type_line": "Token Creature — Dragon",
+              "colors": [
+                "R"
+              ],
+              "power": "5",
+              "toughness": "5"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -50869,6 +57319,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DROWNED (1)",
+      "tokens": [
+        {
+          "name": "Fish",
+          "type_line": "Token Creature — Fish",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -50896,7 +57357,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Fish",
+              "type_line": "Token Creature — Fish",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51066,6 +57538,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "DROWNED (2)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Fish",
+          "type_line": "Token Creature — Fish",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -51121,7 +57609,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Fish",
+              "type_line": "Token Creature — Fish",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51201,7 +57700,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51253,6 +57759,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ELVES (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -51440,6 +57947,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ELVES (2)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -51523,7 +58041,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51627,6 +58156,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ELVES (3)",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -51696,7 +58236,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51814,6 +58365,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ELVES (4)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "G"
+          ],
+          "power": "7",
+          "toughness": "7"
+        },
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -51827,7 +58398,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "G"
+              ],
+              "power": "7",
+              "toughness": "7"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -51974,7 +58556,18 @@
             "G"
           ],
           "rarity": "mythic",
-          "loyalty": "3"
+          "loyalty": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -52002,6 +58595,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCHANTED (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -52189,6 +58783,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCHANTED (2)",
+      "tokens": [
+        {
+          "name": "Warrior",
+          "type_line": "Token Creature — Warrior",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -52336,7 +58941,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Warrior",
+              "type_line": "Token Creature — Warrior",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -52376,6 +58992,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCHANTED (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -52563,6 +59180,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCHANTED (4)",
+      "tokens": [
+        {
+          "name": "Pegasus",
+          "type_line": "Token Creature — Pegasus",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -52576,7 +59204,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Pegasus",
+              "type_line": "Token Creature — Pegasus",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -52750,6 +59389,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCOUNTER (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -52938,6 +59578,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCOUNTER (2)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -52965,7 +59616,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53126,6 +59788,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCOUNTER (3)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -53153,7 +59826,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53314,6 +59998,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ENCOUNTER (4)",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -53461,7 +60156,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53502,6 +60208,18 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "EXPLORERS (1)",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -53611,7 +60329,19 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            },
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53687,6 +60417,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "EXPLORERS (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -53700,7 +60446,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53782,7 +60535,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53844,7 +60604,23 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            },
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53872,6 +60648,49 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "EXPLORERS (3)",
+      "tokens": [
+        {
+          "name": "Beast",
+          "type_line": "Token Creature — Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -53885,7 +60704,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53899,7 +60725,36 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "4",
+              "toughness": "4"
+            },
+            {
+              "name": "Beast",
+              "type_line": "Token Creature — Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            },
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53953,7 +60808,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -53967,7 +60833,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54029,7 +60902,23 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            },
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54057,6 +60946,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "EXPLORERS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -54242,6 +61132,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "FUN GUYS (1)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -54255,7 +61156,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54269,7 +61181,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54325,7 +61248,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54349,7 +61283,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54385,7 +61330,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54397,7 +61353,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54425,6 +61392,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "FUN GUYS (2)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -54438,7 +61416,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54452,7 +61441,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "7"
+          "toughness": "7",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54466,7 +61466,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54494,7 +61505,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54532,7 +61554,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54568,7 +61601,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54580,7 +61624,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54608,6 +61663,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GHASTLY (1)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -54649,7 +61715,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54705,7 +61782,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54729,7 +61817,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54793,6 +61892,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GHASTLY (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -54834,7 +61944,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54914,7 +62035,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -54978,6 +62110,32 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GHASTLY (3)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        },
+        {
+          "name": "Worm",
+          "type_line": "Token Creature — Worm",
+          "colors": [
+            "B",
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55005,7 +62163,19 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Worm",
+              "type_line": "Token Creature — Worm",
+              "colors": [
+                "B",
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55033,7 +62203,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55113,7 +62294,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55165,6 +62353,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GHASTLY (4)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        },
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55192,7 +62396,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55206,7 +62417,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55248,7 +62470,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55260,7 +62493,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55284,7 +62528,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55296,7 +62551,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55348,6 +62610,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GIDDYAP",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55361,7 +62630,14 @@
           ],
           "rarity": "mythic",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55535,6 +62811,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GOBLINS (1)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55562,7 +62849,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55576,7 +62874,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55644,7 +62953,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55656,7 +62976,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55720,6 +63051,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GOBLINS (2)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55747,7 +63089,18 @@
           ],
           "rarity": "mythic",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55761,7 +63114,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55775,7 +63139,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55829,7 +63204,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55841,7 +63227,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55905,6 +63302,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GOBLINS (3)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -55918,7 +63326,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55932,7 +63351,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -55946,7 +63376,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56014,7 +63455,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56026,7 +63478,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56090,6 +63553,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GOBLINS (4)",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -56103,7 +63577,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56117,7 +63602,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56131,7 +63627,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56199,7 +63706,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56211,7 +63729,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56275,6 +63804,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GRAVE ROBBERS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -56462,6 +63992,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GRAVE ROBBERS (2)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -56609,7 +64146,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56649,6 +64193,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GRAVE ROBBERS (3)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -56690,7 +64245,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -56846,6 +64412,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "GRAVE ROBBERS (4)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -57004,7 +64581,18 @@
             "B"
           ],
           "rarity": "mythic",
-          "loyalty": "5"
+          "loyalty": "5",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -57032,6 +64620,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEALERS (1)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -57045,7 +64644,18 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -57229,6 +64839,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEALERS (2)",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -57242,7 +64863,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -57416,6 +65048,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEALERS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -57613,6 +65246,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEALERS (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -57800,6 +65434,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEROES (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -57985,6 +65620,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "HEROES (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -58170,6 +65806,27 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ICKY (1)",
+      "tokens": [
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Worm",
+          "type_line": "Token Creature — Worm",
+          "colors": [
+            "B",
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -58183,7 +65840,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58197,7 +65865,19 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Worm",
+              "type_line": "Token Creature — Worm",
+              "colors": [
+                "B",
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58357,6 +66037,27 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ICKY (2)",
+      "tokens": [
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Worm",
+          "type_line": "Token Creature — Worm",
+          "colors": [
+            "B",
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -58370,7 +66071,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58398,7 +66110,19 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Worm",
+              "type_line": "Token Creature — Worm",
+              "colors": [
+                "B",
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58544,6 +66268,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ILLUSIONS",
+      "tokens": [
+        {
+          "name": "Bird Illusion",
+          "type_line": "Token Creature — Bird Illusion",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -58599,7 +66334,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Bird Illusion",
+              "type_line": "Token Creature — Bird Illusion",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58731,6 +66477,15 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "INVENTIVE (1)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -58744,7 +66499,16 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58784,7 +66548,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58880,7 +66653,16 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58918,6 +66700,15 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "INVENTIVE (2)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -58931,7 +66722,16 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -58985,7 +66785,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -59101,6 +66910,15 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "INVENTIVE (3)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -59168,7 +66986,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -59288,6 +67115,15 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "INVENTIVE (4)",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -59353,7 +67189,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -59471,6 +67316,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LANDFALL (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -59654,6 +67500,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LANDFALL (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -59839,6 +67686,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LANDFALL (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -60020,6 +67868,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LANDFALL (4)",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -60117,7 +67976,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60203,6 +68073,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LEGION (1)",
+      "tokens": [
+        {
+          "name": "Human",
+          "type_line": "Token Creature — Human",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -60216,7 +68106,18 @@
           ],
           "rarity": "rare",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human",
+              "type_line": "Token Creature — Human",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60312,7 +68213,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60348,7 +68260,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60388,6 +68311,35 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "LEGION (2)",
+      "tokens": [
+        {
+          "name": "Human",
+          "type_line": "Token Creature — Human",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -60401,7 +68353,18 @@
           ],
           "rarity": "rare",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human",
+              "type_line": "Token Creature — Human",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60483,7 +68446,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60495,7 +68469,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60531,7 +68516,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60553,7 +68549,18 @@
           "mana_cost": "",
           "cmc": 0.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60581,6 +68588,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "MODIFIED",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Wolf",
+          "type_line": "Token Creature — Wolf",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -60608,7 +68635,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60712,7 +68750,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Wolf",
+              "type_line": "Token Creature — Wolf",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -60774,6 +68823,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "NEFARIOUS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -60957,6 +69007,18 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "NER-DO-WELLS (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -60970,7 +69032,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61080,7 +69149,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61092,7 +69168,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61116,7 +69199,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61144,6 +69234,18 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "NER-DO-WELLS (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -61157,7 +69259,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61267,7 +69376,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61279,7 +69395,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61291,7 +69414,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61303,7 +69433,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61331,6 +69468,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "NINJAS",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -61442,7 +69586,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -61518,6 +69669,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "OF THE COAST (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -61715,6 +69867,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "OF THE COAST (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -61912,6 +70065,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "PRIDEFUL",
+      "tokens": [
+        {
+          "name": "Cat Soldier",
+          "type_line": "Token Creature — Cat Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -61925,7 +70089,18 @@
           ],
           "rarity": "mythic",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Cat Soldier",
+              "type_line": "Token Creature — Cat Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -62097,6 +70272,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SNAKES",
+      "tokens": [
+        {
+          "name": "Snake",
+          "type_line": "Token Creature — Snake",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -62110,7 +70296,18 @@
           ],
           "rarity": "mythic",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Snake",
+              "type_line": "Token Creature — Snake",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -62282,6 +70479,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SOARING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -62467,6 +70665,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SOARING (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -62652,6 +70851,24 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SOARING (3)",
+      "tokens": [
+        {
+          "name": "Elemental Bird",
+          "type_line": "Token Creature — Elemental Bird",
+          "colors": [
+            "U"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -62721,7 +70938,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -62810,7 +71036,18 @@
             "U"
           ],
           "rarity": "mythic",
-          "loyalty": "2"
+          "loyalty": "2",
+          "tokens": [
+            {
+              "name": "Elemental Bird",
+              "type_line": "Token Creature — Elemental Bird",
+              "colors": [
+                "U"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -62838,6 +71075,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SOARING (4)",
+      "tokens": [
+        {
+          "name": "Faerie",
+          "type_line": "Token Creature — Faerie",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -62947,7 +71195,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Faerie",
+              "type_line": "Token Creature — Faerie",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63023,6 +71282,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STALWART (1)",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -63106,7 +71385,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63183,7 +71473,18 @@
             "W"
           ],
           "rarity": "mythic",
-          "loyalty": "4"
+          "loyalty": "4",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63211,6 +71512,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STALWART (2)",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -63224,7 +71545,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63294,7 +71626,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63408,6 +71751,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STALWART (3)",
+      "tokens": [
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Vampire",
+          "type_line": "Token Creature — Vampire",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -63491,7 +71854,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Vampire",
+              "type_line": "Token Creature — Vampire",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63519,7 +71893,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63595,6 +71980,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STALWART (4)",
+      "tokens": [
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -63678,7 +72074,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63782,6 +72189,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STOKED (1)",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -63937,7 +72355,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -63965,6 +72394,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STOKED (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -64150,6 +72580,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STOKED (3)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -64205,7 +72655,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -64233,7 +72694,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -64305,7 +72777,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -64333,6 +72816,26 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "STOKED (4)",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -64374,7 +72877,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -64430,7 +72944,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -64518,6 +73043,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SURPRISE! (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -64705,6 +73231,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SURPRISE! (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -64892,6 +73419,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SURPRISE! (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -65079,6 +73607,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "SURPRISE! (4)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -65266,6 +73795,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "TOO MANY",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -65347,7 +73887,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65395,7 +73946,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65435,6 +73997,22 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "TREASURES (1)",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -65462,7 +74040,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65476,7 +74061,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65490,7 +74082,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65504,7 +74103,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65532,7 +74138,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65546,7 +74159,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65558,7 +74178,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65570,7 +74197,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65582,7 +74216,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65594,7 +74235,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65622,6 +74274,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "TREASURES (2)",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -65649,7 +74308,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65663,7 +74329,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65691,7 +74364,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65719,7 +74399,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65733,7 +74420,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65745,7 +74439,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65769,7 +74470,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65781,7 +74489,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65819,6 +74534,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "VAMPIRES (1)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -65916,7 +74638,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -65966,7 +74695,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66006,6 +74742,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "VAMPIRES (2)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -66103,7 +74846,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66165,7 +74915,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66193,6 +74950,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "VAMPIRES (3)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -66276,7 +75040,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66340,7 +75111,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66380,6 +75158,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "VAMPIRES (4)",
+      "tokens": [
+        {
+          "name": "Blood",
+          "type_line": "Token Artifact — Blood",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -66463,7 +75248,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66539,7 +75331,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Blood",
+              "type_line": "Token Artifact — Blood",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -66567,6 +75366,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "WARRIORS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -66762,6 +75562,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "WARRIORS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -66957,6 +75758,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "WIZARDS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -67144,6 +75946,17 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "WIZARDS (2)",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -67171,7 +75984,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -67331,6 +76155,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ZEALOTS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -67526,6 +76351,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ZEALOTS (2)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -67539,7 +76371,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -67711,6 +76550,7 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ZEALOTS (3)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -67906,6 +76746,13 @@
       "set": "J25",
       "set_name": "JumpStart Foundations",
       "deck_name": "ZEALOTS (4)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -67919,7 +76766,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68093,6 +76947,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "AANG",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -68134,7 +76999,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68176,7 +77052,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68190,7 +77077,18 @@
           ],
           "rarity": "mythic",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68252,7 +77150,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68277,7 +77186,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -68285,6 +77199,24 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ADAPTIVE",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -68406,7 +77338,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68440,7 +77381,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68465,7 +77417,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -68473,6 +77430,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ADEPT (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -68501,7 +77465,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68656,7 +77627,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -68664,6 +77640,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ADEPT (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -68810,7 +77793,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -68847,7 +77837,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -68855,6 +77850,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "AIRBENDING",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -68882,7 +77888,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69014,7 +78031,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69039,7 +78067,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -69047,6 +78080,22 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ALLIANCE (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -69131,7 +78180,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69146,7 +78206,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69173,7 +78244,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69207,7 +78285,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69232,7 +78321,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -69240,6 +78334,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ALLIANCE (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -69324,7 +78429,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69339,7 +78455,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69424,14 +78551,26 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:AT-THE-ZOO": {
+    "TLA:AT THE ZOO": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "AT-THE-ZOO",
+      "deck_name": "AT THE ZOO",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -69501,7 +78640,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69617,7 +78763,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -69625,6 +78776,25 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "AZULA",
+      "tokens": [
+        {
+          "name": "Ballistic Boulder",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [],
+          "power": "2",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -69680,7 +78850,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ballistic Boulder",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69722,7 +78901,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69770,7 +78956,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69807,14 +79000,31 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:BAD-ADVICE": {
+    "TLA:BAD ADVICE": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "BAD-ADVICE",
+      "deck_name": "BAD ADVICE",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -69870,7 +79080,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -69976,7 +79193,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70001,14 +79225,44 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:BOUNTY-HUNTER (1)": {
+    "TLA:BOUNTY HUNTER (1)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "BOUNTY-HUNTER (1)",
+      "deck_name": "BOUNTY HUNTER (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -70037,7 +79291,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70051,7 +79316,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70093,7 +79365,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70121,7 +79400,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70145,7 +79431,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70169,7 +79462,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70194,14 +79498,51 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:BOUNTY-HUNTER (2)": {
+    "TLA:BOUNTY HUNTER (2)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "BOUNTY-HUNTER (2)",
+      "deck_name": "BOUNTY HUNTER (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Ballistic Boulder",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [],
+          "power": "2",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -70215,7 +79556,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70230,7 +79578,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70244,7 +79603,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70272,7 +79638,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ballistic Boulder",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70286,7 +79661,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70315,7 +79697,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70339,7 +79728,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70351,7 +79747,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70363,7 +79766,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70388,7 +79802,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -70396,6 +79815,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "BUMI",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -70492,7 +79918,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70540,7 +79973,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70577,7 +80017,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -70585,6 +80030,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "CABBAGES",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -70598,7 +80050,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70612,7 +80071,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70626,7 +80092,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70654,7 +80127,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70694,7 +80174,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70706,7 +80193,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70718,7 +80212,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70742,7 +80243,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70767,14 +80275,30 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:EARTH-KINGDOM (1)": {
+    "TLA:EARTH KINGDOM (1)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "EARTH-KINGDOM (1)",
+      "deck_name": "EARTH KINGDOM (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -70817,7 +80341,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70872,7 +80407,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70907,7 +80453,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -70954,14 +80511,30 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:EARTH-KINGDOM (2)": {
+    "TLA:EARTH KINGDOM (2)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "EARTH-KINGDOM (2)",
+      "deck_name": "EARTH KINGDOM (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -71032,7 +80605,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -71146,14 +80730,30 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:EARTH-RUMBLE (1)": {
+    "TLA:EARTH RUMBLE (1)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "EARTH-RUMBLE (1)",
+      "deck_name": "EARTH RUMBLE (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -71300,7 +80900,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -71337,14 +80948,44 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:EARTH-RUMBLE (2)": {
+    "TLA:EARTH RUMBLE (2)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "EARTH-RUMBLE (2)",
+      "deck_name": "EARTH RUMBLE (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Bear",
+          "type_line": "Token Creature — Bear",
+          "colors": [
+            "G"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -71401,7 +81042,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Bear",
+              "type_line": "Token Creature — Bear",
+              "colors": [
+                "G"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -71444,7 +81096,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -71491,7 +81150,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -71528,7 +81198,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -71536,6 +81211,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "EARTHBENDING (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -71715,7 +81391,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -71723,6 +81404,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "EARTHBENDING (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -71902,14 +81584,35 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:FIRE-NATION": {
+    "TLA:FIRE NATION": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "FIRE-NATION",
+      "deck_name": "FIRE NATION",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -72004,7 +81707,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72028,7 +81742,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72089,7 +81810,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -72097,6 +81823,31 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "FIREBENDING (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -72138,7 +81889,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72228,7 +81990,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72252,7 +82021,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72277,7 +82057,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -72285,6 +82070,31 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "FIREBENDING (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -72340,7 +82150,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72406,7 +82227,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72430,7 +82262,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72467,14 +82306,30 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:FREEDOM-FIGHTERS": {
+    "TLA:FREEDOM FIGHTERS": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "FREEDOM-FIGHTERS",
+      "deck_name": "FREEDOM FIGHTERS",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -72624,7 +82479,18 @@
             "R",
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72636,7 +82502,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72661,7 +82538,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -72669,6 +82551,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "GLIDING (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -72828,7 +82721,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -72853,7 +82757,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -72861,6 +82770,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "GLIDING (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73020,7 +82940,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73045,14 +82976,30 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:HEI-BAI (1)": {
+    "TLA:HEI BAI (1)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "HEI-BAI (1)",
+      "deck_name": "HEI BAI (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73066,7 +83013,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73081,7 +83039,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73124,7 +83093,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73215,7 +83195,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73240,14 +83231,35 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:HEI-BAI (2)": {
+    "TLA:HEI BAI (2)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "HEI-BAI (2)",
+      "deck_name": "HEI BAI (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73290,7 +83302,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73319,7 +83342,18 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73386,7 +83420,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73410,7 +83451,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73435,7 +83487,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -73443,6 +83500,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "HUNTING (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73484,7 +83548,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73498,7 +83569,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73513,7 +83591,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73629,7 +83714,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -73637,6 +83727,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "HUNTING (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73678,7 +83775,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73692,7 +83796,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73707,7 +83818,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73823,7 +83941,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -73831,6 +83954,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "INSURGENT (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -73886,7 +84020,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -73914,7 +84059,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74016,7 +84172,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74024,6 +84185,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "INSURGENT (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -74108,7 +84280,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74173,7 +84356,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74210,7 +84404,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74218,6 +84417,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "IROH",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -74401,7 +84601,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74409,6 +84614,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "KATARA",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -74592,7 +84798,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74600,6 +84811,22 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "KYOSHI",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -74627,7 +84854,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74656,7 +84890,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74743,7 +84988,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74780,7 +85036,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74788,6 +85049,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "LEARNING (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -74931,7 +85199,14 @@
           "mana_cost": "{5}",
           "cmc": 5.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -74968,7 +85243,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -74976,6 +85256,18 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "LEARNING (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -75074,7 +85366,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75098,7 +85397,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75120,7 +85426,14 @@
           "mana_cost": "{5}",
           "cmc": 5.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75157,7 +85470,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -75165,6 +85483,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "LESSONS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -75347,7 +85666,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -75355,6 +85679,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "LESSONS (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -75488,7 +85819,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75537,7 +85875,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -75545,6 +85888,20 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "LIBRARIAN",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -75585,7 +85942,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75613,7 +85977,16 @@
           ],
           "rarity": "mythic",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75639,7 +86012,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75697,7 +86079,14 @@
           "mana_cost": "{5}",
           "cmc": 5.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75722,7 +86111,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -75730,6 +86124,22 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "MUSICIANS",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -75864,7 +86274,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75876,7 +86293,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75888,7 +86316,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75923,7 +86362,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -75931,6 +86375,32 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "NIGHTMARES",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -75959,7 +86429,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -75973,7 +86454,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76001,7 +86489,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76030,7 +86525,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76117,7 +86619,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -76125,6 +86632,25 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "OZAI",
+      "tokens": [
+        {
+          "name": "Ballistic Boulder",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [],
+          "power": "2",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -76138,7 +86664,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76180,7 +86713,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ballistic Boulder",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76237,7 +86779,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76310,7 +86859,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -76318,6 +86872,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "POWERFUL (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -76389,7 +86950,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76504,7 +87072,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -76512,6 +87085,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "POWERFUL (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -76582,7 +87162,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76698,7 +87285,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -76706,6 +87298,31 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "REBELLING (1)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -76747,7 +87364,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76841,7 +87469,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76853,7 +87492,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -76890,7 +87536,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -76898,6 +87549,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "REBELLING (2)",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -76939,7 +87601,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77058,7 +87731,18 @@
             "R",
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77083,7 +87767,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -77091,6 +87780,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "REINFORCED (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -77104,7 +87800,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77277,7 +87980,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -77285,6 +87993,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "REINFORCED (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -77472,7 +88181,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -77480,6 +88194,27 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "RELENTLESS (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -77563,7 +88298,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77591,7 +88333,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77603,7 +88352,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77639,7 +88395,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77664,7 +88431,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -77672,6 +88444,32 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "RELENTLESS (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -77685,7 +88483,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77713,7 +88518,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77741,7 +88553,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77784,7 +88603,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77832,7 +88658,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -77857,7 +88694,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -77865,6 +88707,26 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ROKU",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Monk",
+          "type_line": "Token Creature — Monk",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -77920,7 +88782,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78010,7 +88883,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Monk",
+              "type_line": "Token Creature — Monk",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78045,7 +88929,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -78053,6 +88942,24 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "SHRINES",
+      "tokens": [
+        {
+          "name": "Monk",
+          "type_line": "Token Creature — Monk",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -78094,7 +89001,16 @@
           ],
           "rarity": "mythic",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78203,7 +89119,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Monk",
+              "type_line": "Token Creature — Monk",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78278,14 +89205,47 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:SIEGE-ENGINES": {
+    "TLA:SIEGE ENGINES": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "SIEGE-ENGINES",
+      "deck_name": "SIEGE ENGINES",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Ballistic Boulder",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [],
+          "power": "2",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -78299,7 +89259,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78328,7 +89295,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78356,7 +89334,16 @@
           ],
           "rarity": "uncommon",
           "power": "0",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ballistic Boulder",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78384,7 +89371,14 @@
           ],
           "rarity": "common",
           "power": "6",
-          "toughness": "6"
+          "toughness": "6",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78418,7 +89412,14 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78467,7 +89468,12 @@
         {
           "quantity": 1,
           "name": "Swamp Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Swamp",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -78475,6 +89481,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "SOARING (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -78502,7 +89515,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78517,7 +89537,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78546,7 +89573,14 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78660,7 +89694,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -78668,6 +89707,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "SOARING (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -78710,7 +89756,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -78855,14 +89908,20 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:SPARKY-SPARKY (1)": {
+    "TLA:SPARKY SPARKY (1)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "SPARKY-SPARKY (1)",
+      "deck_name": "SPARKY SPARKY (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -79046,14 +90105,20 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
-    "TLA:SPARKY-SPARKY (2)": {
+    "TLA:SPARKY SPARKY (2)": {
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
-      "deck_name": "SPARKY-SPARKY (2)",
+      "deck_name": "SPARKY SPARKY (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -79236,7 +90301,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -79244,6 +90314,20 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "SPIRIT",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -79285,7 +90369,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -79313,7 +90404,16 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -79353,7 +90453,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -79426,7 +90535,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -79434,6 +90548,22 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "SWORDMASTER",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -79529,7 +90659,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -79551,7 +90688,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -79608,7 +90756,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -79616,6 +90769,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "TOPH",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -79801,7 +90955,12 @@
         {
           "quantity": 1,
           "name": "Forest Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Forest",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -79809,6 +90968,7 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "UNDERWATER",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -79987,7 +91147,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -79995,6 +91160,22 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "WARRIORS",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80022,7 +91203,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80079,7 +91271,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80105,7 +91308,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80127,7 +91337,18 @@
           "mana_cost": "{2}",
           "cmc": 2.0,
           "colors": [],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80139,7 +91360,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80176,7 +91408,12 @@
         {
           "quantity": 1,
           "name": "Plains Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Plains",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -80184,6 +91421,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "WISE (1)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80211,7 +91455,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80268,7 +91519,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80367,7 +91625,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -80375,6 +91638,13 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "WISE (2)",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80416,7 +91686,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80460,7 +91737,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80561,7 +91845,12 @@
         {
           "quantity": 1,
           "name": "Island Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Island",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -80569,6 +91858,17 @@
       "set": "TLA",
       "set_name": "Avatar: The Last Airbender",
       "deck_name": "ZUKO",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80650,7 +91950,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80747,7 +92058,12 @@
         {
           "quantity": 1,
           "name": "Mountain Appa",
-          "type": "Unknown"
+          "type": "Lands",
+          "type_line": "Basic Land — Mountain",
+          "mana_cost": "",
+          "cmc": 0.0,
+          "colors": [],
+          "rarity": "common"
         }
       ]
     },
@@ -80755,6 +92071,13 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "CORRUPTION (1)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80768,7 +92091,14 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80929,6 +92259,20 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "CORRUPTION (2)",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Phyrexian Mite",
+          "type_line": "Token Artifact Creature — Phyrexian Mite",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -80942,7 +92286,14 @@
           ],
           "rarity": "rare",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -80970,7 +92321,16 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81107,6 +92467,15 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "MITE-Y (1)",
+      "tokens": [
+        {
+          "name": "Phyrexian Mite",
+          "type_line": "Token Artifact Creature — Phyrexian Mite",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -81120,7 +92489,16 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81176,7 +92554,16 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81216,7 +92603,16 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81240,7 +92636,16 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81285,6 +92690,15 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "MITE-Y (2)",
+      "tokens": [
+        {
+          "name": "Phyrexian Mite",
+          "type_line": "Token Artifact Creature — Phyrexian Mite",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -81298,7 +92712,16 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81326,7 +92749,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Phyrexian Mite",
+              "type_line": "Token Artifact Creature — Phyrexian Mite",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81463,6 +92895,7 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "PROGRESS (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -81641,6 +93074,7 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "PROGRESS (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -81813,6 +93247,26 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "REBELLIOUS (1)",
+      "tokens": [
+        {
+          "name": "Phyrexian Goblin",
+          "type_line": "Token Creature — Phyrexian Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -81854,7 +93308,18 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Phyrexian Goblin",
+              "type_line": "Token Creature — Phyrexian Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81930,7 +93395,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81942,7 +93418,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81954,7 +93441,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -81987,6 +93485,17 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "REBELLIOUS (2)",
+      "tokens": [
+        {
+          "name": "Rebel",
+          "type_line": "Token Creature — Rebel",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -82090,7 +93599,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82102,7 +93622,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82114,7 +93645,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Rebel",
+              "type_line": "Token Creature — Rebel",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82157,6 +93699,17 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "TOXIC (1)",
+      "tokens": [
+        {
+          "name": "Phyrexian Beast",
+          "type_line": "Token Creature — Phyrexian Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -82300,7 +93853,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Phyrexian Beast",
+              "type_line": "Token Creature — Phyrexian Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82333,6 +93897,17 @@
       "set": "ONE",
       "set_name": "Phyrexia: All Will Be One",
       "deck_name": "TOXIC (2)",
+      "tokens": [
+        {
+          "name": "Phyrexian Beast",
+          "type_line": "Token Creature — Phyrexian Beast",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -82440,7 +94015,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Phyrexian Beast",
+              "type_line": "Token Creature — Phyrexian Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82464,7 +94050,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Phyrexian Beast",
+              "type_line": "Token Creature — Phyrexian Beast",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82509,6 +94106,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "ARCANE MISCHIEF",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -82695,6 +94293,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "BEAST TERRITORY",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -82925,6 +94524,26 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "COALITION CORPS",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -82952,7 +94571,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -82966,7 +94596,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -83034,7 +94675,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -83070,7 +94722,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 5,
@@ -83113,6 +94776,26 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "COALITION LEGION",
+      "tokens": [
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -83168,7 +94851,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -83258,7 +94952,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 5,
@@ -83301,6 +95006,17 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "MONSTER TERRITORY",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -83446,7 +95162,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -83529,6 +95256,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "MYSTIC MISCHIEF",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -83715,6 +95443,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "READY TO ATTACK",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -83903,6 +95632,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "READY TO CHARGE",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -84091,6 +95821,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "TOTALLY MERCILESS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -84279,6 +96010,7 @@
       "set": "DMU",
       "set_name": "Dominaria United",
       "deck_name": "TOTALLY RUTHLESS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -84467,6 +96199,13 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "INFANTRY (1)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -84608,7 +96347,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 6,
@@ -84641,6 +96387,20 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "INFANTRY (2)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Artifact Creature — Soldier",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -84722,7 +96482,16 @@
           "colors": [],
           "rarity": "common",
           "power": "3",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Artifact Creature — Soldier",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84782,7 +96551,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 6,
@@ -84815,6 +96591,20 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "POWERSTONES (1)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        },
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -84828,7 +96618,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84856,7 +96653,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84870,7 +96676,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84908,7 +96721,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84920,7 +96740,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -84989,6 +96816,20 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "POWERSTONES (2)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        },
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -85002,7 +96843,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85030,7 +96878,16 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85044,7 +96901,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85082,7 +96946,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85106,7 +96977,14 @@
           "colors": [
             "U"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85163,6 +97041,13 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "TITANIC (1)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -85176,7 +97061,14 @@
           ],
           "rarity": "common",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -85333,6 +97225,7 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "TITANIC (2)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -85503,6 +97396,7 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "UNEARTHED (1)",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -85673,6 +97567,15 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "UNEARTHED (2)",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Artifact Creature — Zombie",
+          "colors": [],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -85808,7 +97711,16 @@
           "mana_cost": "{3}",
           "cmc": 3.0,
           "colors": [],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Artifact Creature — Zombie",
+              "colors": [],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 6,
@@ -85841,6 +97753,13 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "WELDED (1)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -85868,7 +97787,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86011,6 +97937,20 @@
       "set": "BRO",
       "set_name": "The Brothers' War",
       "deck_name": "WELDED (2)",
+      "tokens": [
+        {
+          "name": "Powerstone",
+          "type_line": "Token Artifact — Powerstone",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Artifact Creature — Soldier",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86024,7 +97964,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86112,7 +98059,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Powerstone",
+              "type_line": "Token Artifact — Powerstone",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86124,7 +98078,16 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Artifact Creature — Soldier",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86179,6 +98142,13 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "BROOD 1",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86192,7 +98162,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86206,7 +98183,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86248,7 +98232,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86290,7 +98281,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86302,7 +98300,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86349,6 +98354,13 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "BROOD 2",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86362,7 +98374,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86404,7 +98423,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86432,7 +98458,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86460,7 +98493,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86519,6 +98559,13 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "BUFF 1",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86574,7 +98621,14 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86689,6 +98743,13 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "BUFF 2",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86744,7 +98805,14 @@
           ],
           "rarity": "common",
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86836,7 +98904,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -86859,6 +98934,18 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "EXPENDABLE 1",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -86872,7 +98959,14 @@
           ],
           "rarity": "common",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -86992,7 +99086,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87004,7 +99105,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -87027,6 +99135,18 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "EXPENDABLE 2",
+      "tokens": [
+        {
+          "name": "Incubator // Phyrexian",
+          "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87040,7 +99160,14 @@
           ],
           "rarity": "common",
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87110,7 +99237,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87148,7 +99282,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87172,7 +99313,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Incubator // Phyrexian",
+              "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -87195,6 +99343,18 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "OVERACHIEVER 1",
+      "tokens": [
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R",
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87236,7 +99396,19 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R",
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87365,6 +99537,18 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "OVERACHIEVER 2",
+      "tokens": [
+        {
+          "name": "Knight",
+          "type_line": "Token Creature — Knight",
+          "colors": [
+            "U",
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87462,7 +99646,19 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Knight",
+              "type_line": "Token Creature — Knight",
+              "colors": [
+                "U",
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87535,6 +99731,28 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "REINFORCEMENT 1",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "R",
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87604,7 +99822,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87632,7 +99857,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87644,7 +99876,19 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "R",
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87703,6 +99947,18 @@
       "set": "MOM",
       "set_name": "March of the Machine",
       "deck_name": "REINFORCEMENT 2",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87786,7 +100042,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87814,7 +100077,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87873,6 +100143,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "COURAGEOUS 1",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -87942,7 +100219,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -87970,7 +100254,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88041,6 +100332,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "COURAGEOUS 2",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -88110,7 +100408,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88124,7 +100429,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88138,7 +100450,14 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88209,6 +100528,7 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "CUNNING 1",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -88375,6 +100695,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "CUNNING 2",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -88444,7 +100771,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88539,6 +100873,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "ELVEN 1",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -88660,7 +101001,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88705,6 +101053,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "ELVEN 2",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -88814,7 +101169,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88838,7 +101200,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88871,6 +101240,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "JOURNEY 1",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -88884,7 +101260,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88912,7 +101295,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88926,7 +101316,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -88992,7 +101389,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89039,6 +101443,13 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "JOURNEY 2",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89052,7 +101463,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89080,7 +101498,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89094,7 +101519,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89108,7 +101540,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89148,7 +101587,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89160,7 +101606,14 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89207,6 +101660,31 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MARAUDERS 1",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89248,7 +101726,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89288,7 +101777,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89300,7 +101800,23 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            },
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89312,7 +101828,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89336,7 +101863,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89371,6 +101909,31 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MARAUDERS 2",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89412,7 +101975,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89452,7 +102026,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89464,7 +102049,23 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            },
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89476,7 +102077,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89488,7 +102100,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89535,6 +102158,22 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MORDOR 1",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89604,7 +102243,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89618,7 +102268,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89630,7 +102287,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89678,7 +102346,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -89701,6 +102376,22 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MORDOR 2",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89742,7 +102433,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89756,7 +102458,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89770,7 +102483,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89784,7 +102508,14 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89796,7 +102527,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89844,7 +102586,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -89867,6 +102620,22 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MORTALS 1",
+      "tokens": [
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -89908,7 +102677,14 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89964,7 +102740,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -89988,7 +102775,14 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90033,6 +102827,17 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "MORTALS 2",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -90116,7 +102921,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90199,6 +103015,22 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "ORCISH 1",
+      "tokens": [
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -90212,7 +103044,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90226,7 +103069,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90240,7 +103094,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90268,7 +103133,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90282,7 +103154,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90294,7 +103177,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90318,7 +103212,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90365,6 +103270,34 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "ORCISH 2",
+      "tokens": [
+        {
+          "name": "Ballistic Boulder",
+          "type_line": "Token Artifact Creature — Construct",
+          "colors": [],
+          "power": "2",
+          "toughness": "1"
+        },
+        {
+          "name": "Food",
+          "type_line": "Token Artifact — Food",
+          "colors": []
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -90378,7 +103311,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90392,7 +103336,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90406,7 +103361,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90420,7 +103386,16 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ballistic Boulder",
+              "type_line": "Token Artifact Creature — Construct",
+              "colors": [],
+              "power": "2",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90434,7 +103409,14 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90448,7 +103430,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90462,7 +103455,14 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Food",
+              "type_line": "Token Artifact — Food",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90474,7 +103474,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90510,7 +103521,18 @@
           "colors": [
             "B"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -90533,6 +103555,17 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "RIDERS 1",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -90546,7 +103579,18 @@
           ],
           "rarity": "rare",
           "power": "7",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90602,7 +103646,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90614,7 +103669,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90626,7 +103692,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90697,6 +103774,26 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "RIDERS 2",
+      "tokens": [
+        {
+          "name": "Human Soldier",
+          "type_line": "Token Creature — Human Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -90710,7 +103807,18 @@
           ],
           "rarity": "rare",
           "power": "7",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90780,7 +103888,18 @@
           ],
           "rarity": "uncommon",
           "power": "5",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90792,7 +103911,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Human Soldier",
+              "type_line": "Token Creature — Human Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -90840,7 +103970,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -90863,6 +104004,7 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "TRICKSY 1",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -91031,6 +104173,17 @@
       "set": "LTR",
       "set_name": "The Lord of the Rings",
       "deck_name": "TRICKSY 2",
+      "tokens": [
+        {
+          "name": "Orc Army",
+          "type_line": "Token Creature — Orc Army",
+          "colors": [
+            "B"
+          ],
+          "power": "0",
+          "toughness": "0"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -91114,7 +104267,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91176,7 +104340,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Orc Army",
+              "type_line": "Token Creature — Orc Army",
+              "colors": [
+                "B"
+              ],
+              "power": "0",
+              "toughness": "0"
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -91199,6 +104374,13 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "AZORIUS SENATE 1",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -91312,7 +104494,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91410,6 +104599,15 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "AZORIUS SENATE 2",
+      "tokens": [
+        {
+          "name": "Thopter",
+          "type_line": "Token Artifact Creature — Thopter",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -91523,7 +104721,16 @@
             "U",
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Thopter",
+              "type_line": "Token Artifact Creature — Thopter",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91619,6 +104826,31 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "BOROS LEGION 1",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -91632,7 +104864,14 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91716,7 +104955,27 @@
           "colors": [
             "W"
           ],
-          "rarity": "mythic"
+          "rarity": "mythic",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "2",
+              "toughness": "2"
+            },
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91824,6 +105083,22 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "BOROS LEGION 2",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -91950,7 +105225,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -91987,7 +105273,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92035,6 +105328,13 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "CULT OF RAKDOS 1",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -92160,7 +105460,14 @@
           "colors": [
             "B"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92243,6 +105550,13 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "CULT OF RAKDOS 2",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -92343,7 +105657,14 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92455,6 +105776,36 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "GOLGARI SWARM 1",
+      "tokens": [
+        {
+          "name": "Bat",
+          "type_line": "Token Creature — Bat",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Insect",
+          "type_line": "Token Creature — Insect",
+          "colors": [
+            "B",
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -92483,7 +105834,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bat",
+              "type_line": "Token Creature — Bat",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92512,7 +105874,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92556,7 +105929,19 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Insect",
+              "type_line": "Token Creature — Insect",
+              "colors": [
+                "B",
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92664,6 +106049,17 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "GOLGARI SWARM 2",
+      "tokens": [
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -92735,7 +106131,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92816,7 +106223,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -92876,6 +106294,13 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "GRUUL CLANS 1",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -93037,7 +106462,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -93085,6 +106517,22 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "GRUUL CLANS 2",
+      "tokens": [
+        {
+          "name": "Boar",
+          "type_line": "Token Creature — Boar",
+          "colors": [
+            "G"
+          ],
+          "power": "2",
+          "toughness": "2"
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -93184,7 +106632,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Boar",
+              "type_line": "Token Creature — Boar",
+              "colors": [
+                "G"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -93198,7 +106657,14 @@
           ],
           "rarity": "mythic",
           "power": "7",
-          "toughness": "7"
+          "toughness": "7",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -93295,6 +106761,7 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "HOUSE DIMIR 1",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -93504,6 +106971,7 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "HOUSE DIMIR 2",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -93716,6 +107184,13 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "IZZET LEAGUE 1",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -93802,7 +107277,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -93924,6 +107406,22 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "IZZET LEAGUE 2",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Goblin Wizard",
+          "type_line": "Token Creature — Goblin Wizard",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -94035,7 +107533,14 @@
             "R",
             "U"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94047,7 +107552,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin Wizard",
+              "type_line": "Token Creature — Goblin Wizard",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94129,6 +107645,23 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "ORZHOV SYNDICATE 1",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "B",
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -94213,7 +107746,19 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "B",
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94242,7 +107787,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94279,7 +107831,19 @@
             "B",
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "B",
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94339,6 +107903,32 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "ORZHOV SYNDICATE 2",
+      "tokens": [
+        {
+          "name": "Bat",
+          "type_line": "Token Creature — Bat",
+          "colors": [
+            "B"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "B",
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -94381,7 +107971,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Bat",
+              "type_line": "Token Creature — Bat",
+              "colors": [
+                "B"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94423,7 +108024,19 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "B",
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94438,7 +108051,19 @@
           ],
           "rarity": "mythic",
           "power": "4",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "B",
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94451,7 +108076,14 @@
             "B",
             "W"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94464,7 +108096,19 @@
             "B",
             "W"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "B",
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94546,6 +108190,58 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "SELESNYA CONCLAVE 1",
+      "tokens": [
+        {
+          "name": "Angel",
+          "type_line": "Token Creature — Angel",
+          "colors": [
+            "W"
+          ],
+          "power": "4",
+          "toughness": "4"
+        },
+        {
+          "name": "Bird",
+          "type_line": "Token Creature — Bird",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -94559,7 +108255,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94588,7 +108295,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94602,7 +108320,18 @@
           ],
           "rarity": "common",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Bird",
+              "type_line": "Token Creature — Bird",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94617,7 +108346,14 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94631,7 +108367,18 @@
           ],
           "rarity": "uncommon",
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Angel",
+              "type_line": "Token Creature — Angel",
+              "colors": [
+                "W"
+              ],
+              "power": "4",
+              "toughness": "4"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94646,7 +108393,14 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94661,7 +108415,18 @@
           ],
           "rarity": "mythic",
           "power": "1",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94757,6 +108522,41 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "SELESNYA CONCLAVE 2",
+      "tokens": [
+        {
+          "name": "Copy",
+          "type_line": "Token",
+          "colors": []
+        },
+        {
+          "name": "Elemental",
+          "type_line": "Token Creature — Elemental",
+          "colors": [
+            "G",
+            "W"
+          ],
+          "power": "*",
+          "toughness": "*"
+        },
+        {
+          "name": "Saproling",
+          "type_line": "Token Creature — Saproling",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -94770,7 +108570,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94800,7 +108611,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Saproling",
+              "type_line": "Token Creature — Saproling",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94829,7 +108651,14 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Copy",
+              "type_line": "Token",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94858,7 +108687,19 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Elemental",
+              "type_line": "Token Creature — Elemental",
+              "colors": [
+                "G",
+                "W"
+              ],
+              "power": "*",
+              "toughness": "*"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -94966,6 +108807,17 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "SIMIC COMBINE 1",
+      "tokens": [
+        {
+          "name": "Frog Lizard",
+          "type_line": "Token Creature — Frog Lizard",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -95104,7 +108956,18 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Frog Lizard",
+              "type_line": "Token Creature — Frog Lizard",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95174,6 +109037,22 @@
       "set": "CLU",
       "set_name": "Ravnica: Clue Edition",
       "deck_name": "SIMIC COMBINE 2",
+      "tokens": [
+        {
+          "name": "Clue",
+          "type_line": "Token Artifact — Clue",
+          "colors": []
+        },
+        {
+          "name": "Frog Lizard",
+          "type_line": "Token Creature — Frog Lizard",
+          "colors": [
+            "G"
+          ],
+          "power": "3",
+          "toughness": "3"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -95288,7 +109167,14 @@
           ],
           "rarity": "rare",
           "power": "1",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Clue",
+              "type_line": "Token Artifact — Clue",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95316,7 +109202,18 @@
             "G",
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Frog Lizard",
+              "type_line": "Token Creature — Frog Lizard",
+              "colors": [
+                "G"
+              ],
+              "power": "3",
+              "toughness": "3"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95389,6 +109286,17 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "CATS",
+      "tokens": [
+        {
+          "name": "Cat",
+          "type_line": "Token Creature — Cat",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -95486,7 +109394,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Cat",
+              "type_line": "Token Creature — Cat",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95576,6 +109495,17 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "ELVES",
+      "tokens": [
+        {
+          "name": "Elf Warrior",
+          "type_line": "Token Creature — Elf Warrior",
+          "colors": [
+            "G"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -95631,7 +109561,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Elf Warrior",
+              "type_line": "Token Creature — Elf Warrior",
+              "colors": [
+                "G"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95763,6 +109704,17 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "GOBLINS",
+      "tokens": [
+        {
+          "name": "Goblin",
+          "type_line": "Token Creature — Goblin",
+          "colors": [
+            "R"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -95884,7 +109836,18 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Goblin",
+              "type_line": "Token Creature — Goblin",
+              "colors": [
+                "R"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -95946,6 +109909,7 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "HEALING",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -96131,6 +110095,13 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "INFERNO",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -96214,7 +110185,14 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -96240,7 +110218,14 @@
           "colors": [
             "R"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -96304,6 +110289,13 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "PIRATES",
+      "tokens": [
+        {
+          "name": "Treasure",
+          "type_line": "Token Artifact — Treasure",
+          "colors": []
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -96317,7 +110309,14 @@
           ],
           "rarity": "rare",
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Treasure",
+              "type_line": "Token Artifact — Treasure",
+              "colors": []
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -96489,6 +110488,7 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "PRIMAL",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -96662,6 +110662,17 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "UNDEAD",
+      "tokens": [
+        {
+          "name": "Zombie",
+          "type_line": "Token Creature — Zombie",
+          "colors": [
+            "B"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -96745,7 +110756,18 @@
           ],
           "rarity": "uncommon",
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -96773,7 +110795,18 @@
           ],
           "rarity": "common",
           "power": "4",
-          "toughness": "2"
+          "toughness": "2",
+          "tokens": [
+            {
+              "name": "Zombie",
+              "type_line": "Token Creature — Zombie",
+              "colors": [
+                "B"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -96849,6 +110882,7 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "VAMPIRES",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -97036,6 +111070,17 @@
       "set": "FDN",
       "set_name": "Foundations Beginner Box",
       "deck_name": "WIZARDS",
+      "tokens": [
+        {
+          "name": "Faerie",
+          "type_line": "Token Creature — Faerie",
+          "colors": [
+            "U"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -97105,7 +111150,18 @@
           ],
           "rarity": "uncommon",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Faerie",
+              "type_line": "Token Creature — Faerie",
+              "colors": [
+                "U"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97221,6 +111277,17 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "AANG TUTORIAL",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -97382,7 +111449,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 8,
@@ -97400,6 +111478,17 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "ALLIES",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -97484,7 +111573,18 @@
           ],
           "rarity": "uncommon",
           "power": "*",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97546,7 +111646,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "rare"
+          "rarity": "rare",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97558,7 +111669,18 @@
           "colors": [
             "W"
           ],
-          "rarity": "common"
+          "rarity": "common",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97586,6 +111708,17 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "ATTACKING",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -97642,7 +111775,18 @@
           ],
           "rarity": "common",
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97777,6 +111921,17 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "BIG CREATURES",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -97900,7 +112055,18 @@
           "colors": [
             "G"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -97963,6 +112129,7 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "COUNTERS",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -98152,6 +112319,7 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "EARTHBENDING",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -98339,6 +112507,26 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "FIREBENDING",
+      "tokens": [
+        {
+          "name": "Ally",
+          "type_line": "Token Creature — Ally",
+          "colors": [
+            "W"
+          ],
+          "power": "1",
+          "toughness": "1"
+        },
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -98409,7 +112597,18 @@
           ],
           "rarity": "uncommon",
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "tokens": [
+            {
+              "name": "Ally",
+              "type_line": "Token Creature — Ally",
+              "colors": [
+                "W"
+              ],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -98437,7 +112636,18 @@
           ],
           "rarity": "rare",
           "power": "3",
-          "toughness": "4"
+          "toughness": "4",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -98529,6 +112739,15 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "SPELLS",
+      "tokens": [
+        {
+          "name": "Spirit",
+          "type_line": "Token Creature — Spirit",
+          "colors": [],
+          "power": "1",
+          "toughness": "1"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -98638,7 +112857,16 @@
           "colors": [
             "U"
           ],
-          "rarity": "uncommon"
+          "rarity": "uncommon",
+          "tokens": [
+            {
+              "name": "Spirit",
+              "type_line": "Token Creature — Spirit",
+              "colors": [],
+              "power": "1",
+              "toughness": "1"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -98713,6 +112941,7 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "WATERBENDING",
+      "tokens": [],
       "cards": [
         {
           "quantity": 1,
@@ -98900,6 +113129,17 @@
       "set": "TLB",
       "set_name": "Avatar TLA Beginner Box",
       "deck_name": "ZUKO TUTORIAL",
+      "tokens": [
+        {
+          "name": "Soldier",
+          "type_line": "Token Creature — Soldier",
+          "colors": [
+            "R"
+          ],
+          "power": "2",
+          "toughness": "2"
+        }
+      ],
       "cards": [
         {
           "quantity": 1,
@@ -98941,7 +113181,18 @@
           ],
           "rarity": "rare",
           "power": "4",
-          "toughness": "5"
+          "toughness": "5",
+          "tokens": [
+            {
+              "name": "Soldier",
+              "type_line": "Token Creature — Soldier",
+              "colors": [
+                "R"
+              ],
+              "power": "2",
+              "toughness": "2"
+            }
+          ]
         },
         {
           "quantity": 1,
@@ -99083,8 +113334,8 @@
     ],
     "Aang, A Lot to Learn": [
       "TLA:BUMI",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:LEARNING (1)",
       "TLA:LEARNING (2)"
     ],
@@ -99102,7 +113353,7 @@
       "TLB:ALLIES"
     ],
     "Aardvark Sloth": [
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (2)",
       "TLA:SWORDMASTER",
       "TLB:AANG TUTORIAL"
     ],
@@ -99135,8 +113386,8 @@
     ],
     "Acrobatic Leap": [
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS",
-      "TLA:HEI-BAI (1)"
+      "TLA:FREEDOM FIGHTERS",
+      "TLA:HEI BAI (1)"
     ],
     "Acrobatic Maneuver": [
       "J22:BLINK (1)"
@@ -99355,9 +113606,9 @@
       "TLB:ALLIES"
     ],
     "Allies at Last": [
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:KYOSHI"
     ],
     "Allosaurus Shepherd": [
@@ -99490,7 +113741,7 @@
       "JMP:ANGELS (2)"
     ],
     "Animal Attendant": [
-      "TLA:AT-THE-ZOO"
+      "TLA:AT THE ZOO"
     ],
     "Anje's Ravager": [
       "J25:BLOODY (1)"
@@ -99802,8 +114053,8 @@
       "TLB:COUNTERS"
     ],
     "Azula, On the Hunt": [
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:NIGHTMARES",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)"
@@ -99952,8 +114203,8 @@
     ],
     "Bastion of Remembrance": [
       "J25:TREASURES (1)",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)"
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)"
     ],
     "Bathe in Dragonfire": [
       "J25:DRAGONS (1)",
@@ -100009,13 +114260,13 @@
       "FDN:ELVES"
     ],
     "Beetle-Headed Merchants": [
-      "TLA:BOUNTY-HUNTER (1)",
+      "TLA:BOUNTY HUNTER (1)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)",
       "TLA:OZAI",
       "TLA:REINFORCED (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING"
     ],
     "Beetleback Chief": [
@@ -100095,7 +114346,7 @@
       "J25:HEALERS (2)"
     ],
     "Bison Whistle": [
-      "TLA:AT-THE-ZOO"
+      "TLA:AT THE ZOO"
     ],
     "Bite Down": [
       "DMU:BEAST TERRITORY",
@@ -100412,7 +114663,7 @@
     ],
     "Bosco, Just a Bear": [
       "TLA:CABBAGES",
-      "TLA:EARTH-RUMBLE (2)"
+      "TLA:EARTH RUMBLE (2)"
     ],
     "Bounding Wolf": [
       "J22:WOLVES (1)",
@@ -100569,7 +114820,7 @@
     "Bumi Bash": [
       "TLA:MUSICIANS",
       "TLA:REBELLING (1)",
-      "TLA:SPARKY-SPARKY (1)"
+      "TLA:SPARKY SPARKY (1)"
     ],
     "Bumi's Feast Lecture": [
       "TLA:BUMI",
@@ -100647,11 +114898,11 @@
       "JMP:SPOOKY (4)"
     ],
     "Callous Inspector": [
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:OZAI",
       "TLA:REINFORCED (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Campus Guide": [
       "J22:GO TO SCHOOL (2)"
@@ -100681,7 +114932,7 @@
       "TLA:OZAI",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Capital Guard": [
       "TLB:ZUKO TUTORIAL"
@@ -101107,13 +115358,13 @@
     ],
     "Combustion Man": [
       "TLA:POWERFUL (2)",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Combustion Technique": [
       "TLA:FIREBENDING (2)",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Coming In Hot": [
       "MOM:REINFORCEMENT 1"
@@ -101208,7 +115459,7 @@
     ],
     "Corrupt Court Official": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:OZAI",
       "TLB:ATTACKING"
     ],
@@ -101401,7 +115652,7 @@
       "JMP:LANDS (2)"
     ],
     "Cunning Maneuver": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
       "TLA:MUSICIANS",
@@ -101414,7 +115665,7 @@
       "JMP:WELL-READ (4)"
     ],
     "Curious Farm Animals": [
-      "TLA:HEI-BAI (2)"
+      "TLA:HEI BAI (2)"
     ],
     "Curious Obsession": [
       "JMP:PIRATES (2)"
@@ -101451,11 +115702,11 @@
     ],
     "Dai Li Censor": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE"
+      "TLA:BAD ADVICE"
     ],
     "Dai Li Indoctrination": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:REINFORCED (1)",
       "TLA:REINFORCED (2)",
       "TLB:ATTACKING",
@@ -101572,16 +115823,16 @@
       "J22:ZOMBIES (4)"
     ],
     "Deadly Precision": [
-      "TLA:BAD-ADVICE",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BAD ADVICE",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)",
       "TLA:NIGHTMARES",
       "TLA:OZAI",
       "TLA:REINFORCED (2)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Deadly Riposte": [
       "CLU:ORZHOV SYNDICATE 1",
@@ -101636,8 +115887,8 @@
       "J25:ENCOUNTER (4)"
     ],
     "Deer-Dog": [
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Defend the Campus": [
       "J25:LEGION (2)"
@@ -101692,8 +115943,8 @@
       "CLU:CULT OF RAKDOS 2"
     ],
     "Descendants' Path": [
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)"
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)"
     ],
     "Desert of the Fervent": [
       "J25:ZEALOTS (1)",
@@ -101716,7 +115967,7 @@
       "TLA:NIGHTMARES"
     ],
     "Destined Confrontation": [
-      "TLA:HEI-BAI (2)"
+      "TLA:HEI BAI (2)"
     ],
     "Destroy Evil": [
       "J25:ANGELS (1)"
@@ -101749,7 +116000,7 @@
       "J22:DEMONS (2)"
     ],
     "Diligent Zookeeper": [
-      "TLA:AT-THE-ZOO"
+      "TLA:AT THE ZOO"
     ],
     "Dimir Aqueduct": [
       "CLU:HOUSE DIMIR 1",
@@ -101930,7 +116181,7 @@
     ],
     "Dragon Moose": [
       "TLA:FIREBENDING (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO",
       "TLB:ZUKO TUTORIAL"
     ],
@@ -102161,7 +116412,7 @@
       "LTR:MORTALS 2"
     ],
     "Earth Kingdom General": [
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (2)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:TOPH"
@@ -102170,8 +116421,8 @@
       "TLA:SWORDMASTER"
     ],
     "Earth Kingdom Soldier": [
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:KYOSHI",
@@ -102179,14 +116430,14 @@
       "TLB:EARTHBENDING"
     ],
     "Earth Rumble": [
-      "TLA:EARTH-RUMBLE (1)",
+      "TLA:EARTH RUMBLE (1)",
       "TLB:EARTHBENDING"
     ],
     "Earth Rumble Wrestlers": [
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:POWERFUL (1)",
-      "TLA:SPARKY-SPARKY (1)"
+      "TLA:SPARKY SPARKY (1)"
     ],
     "Earth Village Ruffians": [
       "TLA:REINFORCED (2)",
@@ -102233,7 +116484,7 @@
       "J22:LAW (4)"
     ],
     "Eel-Hounds": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLB:BIG CREATURES"
     ],
     "Eerie Soultender": [
@@ -102279,7 +116530,7 @@
       "JMP:LANDS (2)"
     ],
     "Elephant-Mandrill": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:CABBAGES",
       "TLA:KYOSHI"
     ],
@@ -102922,7 +117173,7 @@
     ],
     "Fire Nation Ambushers": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:OZAI",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
@@ -102932,7 +117183,7 @@
       "TLB:FIREBENDING"
     ],
     "Fire Nation Attacks": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (2)",
       "TLA:REBELLING (1)",
       "TLA:ZUKO"
@@ -102940,11 +117191,11 @@
     "Fire Nation Cadets": [
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Fire Nation Engineer": [
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:COUNTERS"
     ],
     "Fire Nation Occupation": [
@@ -102966,16 +117217,16 @@
       "TLB:ZUKO TUTORIAL"
     ],
     "Fire Nation Warship": [
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Fire Nation's Conquest": [
       "TLB:ZUKO TUTORIAL"
     ],
     "Fire Navy Trebuchet": [
       "TLA:AZULA",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:OZAI",
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Fire Prophecy": [
       "J25:COPIED (1)",
@@ -102985,7 +117236,7 @@
     "Fire Sages": [
       "TLA:FIREBENDING (1)",
       "TLA:ROKU",
-      "TLA:SPARKY-SPARKY (1)",
+      "TLA:SPARKY SPARKY (1)",
       "TLB:FIREBENDING"
     ],
     "Fire Urchin": [
@@ -102995,18 +117246,18 @@
       "TLA:FIREBENDING (1)"
     ],
     "Firebending Lesson": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
       "TLA:IROH",
       "TLA:POWERFUL (1)",
       "TLA:POWERFUL (2)",
       "TLA:ROKU",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO"
     ],
     "Firebending Student": [
-      "TLA:FIRE-NATION"
+      "TLA:FIRE NATION"
     ],
     "Firebolt": [
       "J22:EXPERIMENTAL (1)",
@@ -103052,7 +117303,7 @@
     ],
     "Fists of Flame": [
       "J25:COPIED (1)",
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:ZUKO"
     ],
     "Flame Lash": [
@@ -103160,7 +117411,7 @@
     ],
     "Foggy Swamp Vinebender": [
       "TLA:CABBAGES",
-      "TLA:EARTH-KINGDOM (1)"
+      "TLA:EARTH KINGDOM (1)"
     ],
     "Footlight Fiend": [
       "CLU:CULT OF RAKDOS 1",
@@ -103279,13 +117530,13 @@
       "MOM:BUFF 2",
       "ONE:TOXIC (1)",
       "ONE:TOXIC (2)",
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:BUMI",
       "TLA:CABBAGES",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:KYOSHI",
@@ -103297,13 +117548,13 @@
       "TLB:EARTHBENDING"
     ],
     "Forest Appa": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:BUMI",
       "TLA:CABBAGES",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:KYOSHI",
@@ -103370,8 +117621,8 @@
       "J25:ICKY (1)"
     ],
     "Frog-Squirrels": [
-      "TLA:AT-THE-ZOO",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:AT THE ZOO",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:EARTHBENDING (2)",
       "TLA:TOPH",
       "TLB:BIG CREATURES"
@@ -103609,7 +117860,7 @@
       "J22:INSECTS (4)"
     ],
     "Giant Fly": [
-      "TLA:BOUNTY-HUNTER (1)"
+      "TLA:BOUNTY HUNTER (1)"
     ],
     "Giant Growth": [
       "BRO:TITANIC (1)",
@@ -103682,7 +117933,7 @@
       "J22:SHAPESHIFTERS"
     ],
     "Gilacorn": [
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:HUNTING (2)",
       "TLA:REINFORCED (2)",
       "TLB:COUNTERS"
@@ -104090,7 +118341,7 @@
       "J25:LANDFALL (4)"
     ],
     "Great Divide Guide": [
-      "TLA:EARTH-KINGDOM (2)"
+      "TLA:EARTH KINGDOM (2)"
     ],
     "Greenwood Sentinel": [
       "J25:ENCOUNTER (1)",
@@ -104182,7 +118433,7 @@
       "TLA:INSURGENT (2)"
     ],
     "Hama, the Bloodbender": [
-      "TLA:BAD-ADVICE"
+      "TLA:BAD ADVICE"
     ],
     "Hamletback Goliath": [
       "JMP:SMASHING (3)"
@@ -104212,8 +118463,8 @@
       "J25:LANDFALL (4)"
     ],
     "Haru, Hidden Talent": [
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
       "TLB:EARTHBENDING"
     ],
     "Harvester of Souls": [
@@ -104266,7 +118517,7 @@
       "TLA:REINFORCED (2)",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING"
     ],
     "Hearts on Fire": [
@@ -104297,8 +118548,8 @@
       "TLA:SHRINES"
     ],
     "Hei Bai, Spirit of Balance": [
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:NIGHTMARES",
       "TLB:ATTACKING"
     ],
@@ -104384,9 +118635,9 @@
     ],
     "Hippo-Cows": [
       "TLA:CABBAGES",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (1)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (1)",
       "TLA:EARTHBENDING (1)",
       "TLB:BIG CREATURES"
     ],
@@ -104405,9 +118656,9 @@
       "TLB:COUNTERS"
     ],
     "Hog-Monkey Rampage": [
-      "TLA:AT-THE-ZOO",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:AT THE ZOO",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:POWERFUL (2)",
       "TLB:BIG CREATURES"
     ],
@@ -104431,7 +118682,7 @@
       "J25:SNAKES"
     ],
     "Hook Swords": [
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:REBELLING (2)"
     ],
     "Hooting Mandrills": [
@@ -104458,11 +118709,11 @@
       "J22:SPIRITS (2)"
     ],
     "How to Start a Riot": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:POWERFUL (2)",
       "TLA:REBELLING (1)",
       "TLA:REBELLING (2)",
-      "TLA:SPARKY-SPARKY (1)",
+      "TLA:SPARKY SPARKY (1)",
       "TLB:FIREBENDING"
     ],
     "Howl of the Hunt": [
@@ -104719,7 +118970,7 @@
     ],
     "Inspired Insurgent": [
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (2)",
       "TLA:INSURGENT (1)",
       "TLA:INSURGENT (2)",
@@ -104771,7 +119022,7 @@
     "Invasion Reinforcements": [
       "TLA:AANG",
       "TLA:AIRBENDING",
-      "TLA:HEI-BAI (1)",
+      "TLA:HEI BAI (1)",
       "TLA:INSURGENT (1)",
       "TLA:WARRIORS"
     ],
@@ -104807,7 +119058,7 @@
     "Iroh's Demonstration": [
       "TLA:IROH",
       "TLA:POWERFUL (1)",
-      "TLA:SPARKY-SPARKY (1)"
+      "TLA:SPARKY SPARKY (1)"
     ],
     "Iroh, Dragon of the West": [
       "TLA:IROH"
@@ -105044,9 +119295,9 @@
     ],
     "Jeong Jeong's Deserters": [
       "TLA:AIRBENDING",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (2)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (1)"
     ],
     "Jeong Jeong, the Deserter": [
@@ -105065,7 +119316,7 @@
     ],
     "Jet, Rebel Leader": [
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS"
+      "TLA:FREEDOM FIGHTERS"
     ],
     "Jiang Yanggu, Wildcrafter": [
       "J25:ENCOUNTER (1)",
@@ -105081,7 +119332,7 @@
       "JMP:TREE-HUGGING (3)"
     ],
     "Joo Dee, One of Many": [
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:NIGHTMARES",
       "TLA:RELENTLESS (2)"
     ],
@@ -105105,8 +119356,8 @@
       "JMP:ARCHAEOLOGY (4)"
     ],
     "June, Bounty Hunter": [
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)"
     ],
@@ -105313,7 +119564,7 @@
       "TLA:AANG",
       "TLA:AIRBENDING",
       "TLA:GLIDING (1)",
-      "TLA:HEI-BAI (1)"
+      "TLA:HEI BAI (1)"
     ],
     "Kodama of the West Tree": [
       "J25:MODIFIED"
@@ -105394,9 +119645,9 @@
     ],
     "Kyoshi Battle Fan": [
       "TLA:ADAPTIVE",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:KYOSHI",
       "TLA:SWORDMASTER",
       "TLA:WARRIORS"
@@ -105627,7 +119878,7 @@
     ],
     "Lightning Strike": [
       "DMU:READY TO ATTACK",
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:ZUKO",
       "TLB:FIREBENDING"
@@ -105731,7 +119982,7 @@
       "JMP:TREE-HUGGING (4)"
     ],
     "Lo and Li, Royal Advisors": [
-      "TLA:BAD-ADVICE"
+      "TLA:BAD ADVICE"
     ],
     "Lo and Li, Twin Tutors": [
       "TLA:AZULA"
@@ -105754,7 +120005,7 @@
       "J25:OF THE COAST (2)"
     ],
     "Long Feng, Grand Secretariat": [
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:REINFORCED (1)",
       "TLA:REINFORCED (2)",
       "TLB:COUNTERS"
@@ -105763,7 +120014,7 @@
       "JMP:HEAVILY ARMORED (4)"
     ],
     "Longshot, Rebel Bowman": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:REBELLING (1)",
       "TLA:REBELLING (2)"
     ],
@@ -105885,7 +120136,7 @@
       "FDN:PRIMAL"
     ],
     "Mai, Jaded Edge": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:ZUKO"
     ],
     "Majestic Metamorphosis": [
@@ -106029,15 +120280,15 @@
       "J22:WOLVES (2)"
     ],
     "Master's Guidance": [
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:LEARNING (2)"
     ],
     "Master's Rebuke": [
       "J22:LANDFALL (1)"
     ],
     "Match the Odds": [
-      "TLA:EARTH-KINGDOM (1)",
+      "TLA:EARTH KINGDOM (1)",
       "TLB:BIG CREATURES"
     ],
     "Maul of the Skyclaves": [
@@ -106057,8 +120308,8 @@
     "Mechanical Glider": [
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
       "TLA:SOARING (1)",
       "TLB:ALLIES",
       "TLB:BIG CREATURES"
@@ -106099,7 +120350,7 @@
     "Merchant of Many Hats": [
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING"
     ],
     "Merfolk Branchwalker": [
@@ -106550,7 +120801,7 @@
       "MOM:REINFORCEMENT 2",
       "ONE:REBELLIOUS (1)",
       "ONE:REBELLIOUS (2)",
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
       "TLA:IROH",
@@ -106561,14 +120812,14 @@
       "TLA:REBELLING (2)",
       "TLA:ROKU",
       "TLA:SHRINES",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO",
       "TLB:FIREBENDING",
       "TLB:ZUKO TUTORIAL"
     ],
     "Mountain Appa": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
       "TLA:IROH",
@@ -106578,8 +120829,8 @@
       "TLA:REBELLING (1)",
       "TLA:REBELLING (2)",
       "TLA:ROKU",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO"
     ],
     "Mowu, Loyal Companion": [
@@ -106859,8 +121110,8 @@
       "J25:ENCHANTED (3)"
     ],
     "Nyla, Shirshu Sleuth": [
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)"
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)"
     ],
     "Nyx-Fleece Ram": [
       "J25:ENCHANTED (2)",
@@ -106889,7 +121140,7 @@
       "BRO:WELDED (1)"
     ],
     "Obsessive Pursuit": [
-      "TLA:BOUNTY-HUNTER (2)"
+      "TLA:BOUNTY HUNTER (2)"
     ],
     "Obstinate Baloth": [
       "J25:BEASTS (1)"
@@ -107032,10 +121283,10 @@
       "J25:DROWNED (1)"
     ],
     "Origin of Metalbending": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:BUMI",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:LEARNING (1)",
       "TLA:TOPH"
     ],
@@ -107102,7 +121353,7 @@
       "J22:RATS"
     ],
     "Ostrich-Horse": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLB:BIG CREATURES"
     ],
     "Otter-Penguin": [
@@ -107156,7 +121407,7 @@
     ],
     "Overwhelming Victory": [
       "TLA:REBELLING (2)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Owl Familiar": [
       "CLU:AZORIUS SENATE 2",
@@ -107166,7 +121417,7 @@
       "ONE:REBELLIOUS (2)"
     ],
     "Ozai's Cruelty": [
-      "TLA:BAD-ADVICE",
+      "TLA:BAD ADVICE",
       "TLA:OZAI",
       "TLB:COUNTERS"
     ],
@@ -107240,11 +121491,11 @@
       "TLA:AANG",
       "TLA:AIRBENDING",
       "TLA:ALLIANCE (1)",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
       "TLA:GLIDING (2)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (2)",
       "TLA:WARRIORS",
       "TLB:AANG TUTORIAL",
@@ -107403,8 +121654,8 @@
       "J22:INVENTIVE (3)"
     ],
     "Pillar Launch": [
-      "TLA:AT-THE-ZOO",
-      "TLA:EARTH-RUMBLE (1)",
+      "TLA:AT THE ZOO",
+      "TLA:EARTH RUMBLE (1)",
       "TLB:EARTHBENDING"
     ],
     "Pillar of Flame": [
@@ -107425,14 +121676,14 @@
       "LTR:JOURNEY 2"
     ],
     "Pipsqueak, Rebel Strongarm": [
-      "TLA:FREEDOM-FIGHTERS"
+      "TLA:FREEDOM FIGHTERS"
     ],
     "Piranha Marsh": [
       "J22:UNLUCKY THIRTEEN"
     ],
     "Pirate Peddlers": [
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:NIGHTMARES",
       "TLA:RELENTLESS (1)"
     ],
@@ -107585,11 +121836,11 @@
       "TLA:AIRBENDING",
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
       "TLA:GLIDING (2)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (1)",
       "TLA:INSURGENT (2)",
       "TLA:SHRINES",
@@ -107603,11 +121854,11 @@
       "TLA:AIRBENDING",
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
       "TLA:GLIDING (2)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (1)",
       "TLA:INSURGENT (2)",
       "TLA:SWORDMASTER",
@@ -107718,12 +121969,12 @@
       "J22:BLINK (3)"
     ],
     "Pretending Poxbearers": [
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:NIGHTMARES",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING"
     ],
     "Prey Upon": [
@@ -107734,7 +121985,7 @@
       "J22:WOLVES (4)"
     ],
     "Price of Freedom": [
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Prickly Marmoset": [
       "J22:CYCLING (1)",
@@ -107837,7 +122088,7 @@
       "J22:DETECTIVE (2)"
     ],
     "Purple Pentapus": [
-      "TLA:BOUNTY-HUNTER (1)",
+      "TLA:BOUNTY HUNTER (1)",
       "TLA:HUNTING (1)",
       "TLA:NIGHTMARES",
       "TLA:RELENTLESS (1)",
@@ -107899,10 +122150,10 @@
     ],
     "Rabaroo Troop": [
       "TLA:AIRBENDING",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:WARRIORS",
       "TLB:ALLIES"
     ],
@@ -108011,8 +122262,8 @@
       "J25:DINOSAURS (2)"
     ],
     "Ran and Shaw": [
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)"
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)"
     ],
     "Random black rare or mythic rare": [
       "BRO:UNEARTHED (1)",
@@ -108115,8 +122366,8 @@
     ],
     "Raucous Audience": [
       "TLA:BUMI",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:KYOSHI",
       "TLA:SHRINES",
       "TLB:BIG CREATURES"
@@ -108200,7 +122451,7 @@
       "ONE:REBELLIOUS (1)"
     ],
     "Rebellious Captives": [
-      "TLA:EARTH-RUMBLE (1)",
+      "TLA:EARTH RUMBLE (1)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:LEARNING (1)",
@@ -108649,7 +122900,7 @@
       "TLA:RELENTLESS (1)"
     ],
     "Saber-Tooth Moose-Lion": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:CABBAGES",
       "TLA:LEARNING (1)",
       "TLA:LEARNING (2)",
@@ -108710,7 +122961,7 @@
       "J25:VAMPIRES (2)"
     ],
     "Sandbenders' Storm": [
-      "TLA:HEI-BAI (1)"
+      "TLA:HEI BAI (1)"
     ],
     "Sandsteppe Outcast": [
       "J25:STALWART (1)",
@@ -109459,7 +123710,7 @@
     ],
     "Sokka's Sword Training": [
       "TLA:ALLIANCE (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (2)",
       "TLA:SWORDMASTER",
       "TLA:WARRIORS"
     ],
@@ -109482,9 +123733,9 @@
     ],
     "Sold Out": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BAD ADVICE",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:RELENTLESS (1)"
     ],
     "Soldier of the Grey Host": [
@@ -109704,7 +123955,7 @@
       "CLU:GRUUL CLANS 2"
     ],
     "Stand United": [
-      "TLA:EARTH-KINGDOM (1)",
+      "TLA:EARTH KINGDOM (1)",
       "TLA:INSURGENT (1)",
       "TLA:INSURGENT (2)"
     ],
@@ -109866,7 +124117,7 @@
       "JMP:WIZARDS (4)"
     ],
     "Storm of Memories": [
-      "TLA:FIRE-NATION"
+      "TLA:FIRE NATION"
     ],
     "Stormblood Berserker": [
       "CLU:GRUUL CLANS 1"
@@ -109901,8 +124152,8 @@
       "J25:DROWNED (2)"
     ],
     "Suki, Courageous Rescuer": [
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)"
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)"
     ],
     "Suki, Kyoshi Captain": [
       "TLA:WARRIORS"
@@ -109910,8 +124161,8 @@
     "Suki, Kyoshi Warrior": [
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
       "TLA:KYOSHI",
       "TLB:ALLIES"
     ],
@@ -110101,9 +124352,9 @@
       "ONE:CORRUPTION (1)",
       "ONE:CORRUPTION (2)",
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BAD ADVICE",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)",
       "TLA:NIGHTMARES",
@@ -110113,15 +124364,15 @@
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
       "TLA:SHRINES",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING",
       "TLB:COUNTERS"
     ],
     "Swamp Appa": [
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BAD ADVICE",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)",
       "TLA:NIGHTMARES",
@@ -110130,7 +124381,7 @@
       "TLA:REINFORCED (2)",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Swampsnare Trap": [
       "TLA:HUNTING (2)"
@@ -110400,8 +124651,8 @@
       "J22:INVENTIVE (1)"
     ],
     "That's Rough Buddy": [
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (2)"
     ],
     "Thaumaturge's Familiar": [
@@ -110423,8 +124674,8 @@
       "TLA:WISE (2)"
     ],
     "The Boulder, Ready to Rumble": [
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)"
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)"
     ],
     "The Cabbage Merchant": [
       "TLA:CABBAGES"
@@ -110442,17 +124693,17 @@
     "The Duke, Rebel Sentry": [
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS"
+      "TLA:FREEDOM FIGHTERS"
     ],
     "The Earth King": [
-      "TLA:EARTH-RUMBLE (2)"
+      "TLA:EARTH RUMBLE (2)"
     ],
     "The Fair Basilica": [
       "ONE:MITE-Y (1)",
       "ONE:MITE-Y (2)"
     ],
     "The Fire Nation Drill": [
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "The Hunter Maze": [
       "ONE:TOXIC (1)",
@@ -110649,7 +124900,7 @@
       "JMP:SPELLCASTING (3)",
       "JMP:SPELLCASTING (4)",
       "JMP:SPELLINGCASTING (1)",
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
       "TLA:IROH",
@@ -110659,8 +124910,8 @@
       "TLA:REBELLING (1)",
       "TLA:REBELLING (2)",
       "TLA:ROKU",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO",
       "TLB:FIREBENDING"
     ],
@@ -110740,13 +124991,13 @@
       "JMP:TREE-HUGGING (3)",
       "JMP:TREE-HUGGING (4)",
       "JMP:WALLS",
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:BUMI",
       "TLA:CABBAGES",
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLA:KYOSHI",
@@ -110838,11 +125089,11 @@
       "TLA:AIRBENDING",
       "TLA:ALLIANCE (1)",
       "TLA:ALLIANCE (2)",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
       "TLA:GLIDING (2)",
-      "TLA:HEI-BAI (1)",
-      "TLA:HEI-BAI (2)",
+      "TLA:HEI BAI (1)",
+      "TLA:HEI BAI (2)",
       "TLA:INSURGENT (1)",
       "TLA:INSURGENT (2)",
       "TLA:SWORDMASTER",
@@ -111019,9 +125270,9 @@
       "JMP:WITCHCRAFT (1)",
       "JMP:WITCHCRAFT (2)",
       "TLA:AZULA",
-      "TLA:BAD-ADVICE",
-      "TLA:BOUNTY-HUNTER (1)",
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BAD ADVICE",
+      "TLA:BOUNTY HUNTER (1)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:HUNTING (1)",
       "TLA:HUNTING (2)",
       "TLA:NIGHTMARES",
@@ -111030,7 +125281,7 @@
       "TLA:REINFORCED (2)",
       "TLA:RELENTLESS (1)",
       "TLA:RELENTLESS (2)",
-      "TLA:SIEGE-ENGINES",
+      "TLA:SIEGE ENGINES",
       "TLB:ATTACKING",
       "TLB:COUNTERS"
     ],
@@ -111185,9 +125436,9 @@
       "TLA:TOPH"
     ],
     "Toph, the Blind Bandit": [
-      "TLA:EARTH-KINGDOM (1)",
-      "TLA:EARTH-KINGDOM (2)",
-      "TLA:EARTH-RUMBLE (1)",
+      "TLA:EARTH KINGDOM (1)",
+      "TLA:EARTH KINGDOM (2)",
+      "TLA:EARTH RUMBLE (1)",
       "TLA:EARTHBENDING (1)",
       "TLA:EARTHBENDING (2)",
       "TLB:EARTHBENDING"
@@ -111215,7 +125466,7 @@
       "J22:DRAGONS (2)"
     ],
     "Toucan-Puffin": [
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:GLIDING (1)",
       "TLA:WARRIORS"
     ],
@@ -111378,7 +125629,7 @@
       "J25:FUN GUYS (1)"
     ],
     "Tundra Tank": [
-      "TLA:SIEGE-ENGINES"
+      "TLA:SIEGE ENGINES"
     ],
     "Tundra Wall": [
       "TLB:AANG TUTORIAL"
@@ -111401,7 +125652,7 @@
       "JMP:SMASHING (4)"
     ],
     "Turtle-Duck": [
-      "TLA:AT-THE-ZOO",
+      "TLA:AT THE ZOO",
       "TLA:EARTHBENDING (1)",
       "TLB:BIG CREATURES"
     ],
@@ -111430,7 +125681,7 @@
       "J25:TOO MANY"
     ],
     "Ty Lee, Artful Acrobat": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:MUSICIANS"
     ],
     "Typhoid Rats": [
@@ -111486,8 +125737,8 @@
       "FDN:WIZARDS"
     ],
     "Uncle Iroh": [
-      "TLA:EARTH-RUMBLE (1)",
-      "TLA:EARTH-RUMBLE (2)",
+      "TLA:EARTH RUMBLE (1)",
+      "TLA:EARTH RUMBLE (2)",
       "TLA:LEARNING (2)",
       "TLA:POWERFUL (1)",
       "TLA:POWERFUL (2)"
@@ -111644,7 +125895,7 @@
       "J25:HEROES (1)",
       "J25:HEROES (2)",
       "JMP:UNICORNS",
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:WARRIORS"
     ],
     "Valorous Steed": [
@@ -111731,7 +125982,7 @@
       "FDN:VAMPIRES"
     ],
     "Vengeful Villagers": [
-      "TLA:HEI-BAI (1)"
+      "TLA:HEI BAI (1)"
     ],
     "Venomous Brutalizer": [
       "ONE:TOXIC (1)"
@@ -111944,7 +126195,7 @@
     ],
     "Walltop Sentries": [
       "TLA:BUMI",
-      "TLA:EARTH-KINGDOM (2)",
+      "TLA:EARTH KINGDOM (2)",
       "TLA:LEARNING (1)",
       "TLA:LEARNING (2)",
       "TLA:SHRINES"
@@ -111953,12 +126204,12 @@
       "TLA:LIBRARIAN"
     ],
     "Wandering Musicians": [
-      "TLA:FREEDOM-FIGHTERS",
+      "TLA:FREEDOM FIGHTERS",
       "TLA:MUSICIANS"
     ],
     "War Balloon": [
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO"
     ],
     "War Screecher": [
@@ -112392,7 +126643,7 @@
       "TLA:FIREBENDING (2)",
       "TLA:REBELLING (1)",
       "TLA:ROKU",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (2)",
       "TLA:ZUKO",
       "TLB:FIREBENDING"
     ],
@@ -112423,7 +126674,7 @@
       "MOM:OVERACHIEVER 2"
     ],
     "Zhao, Ruthless Admiral": [
-      "TLA:BOUNTY-HUNTER (2)",
+      "TLA:BOUNTY HUNTER (2)",
       "TLA:OZAI",
       "TLA:RELENTLESS (2)"
     ],
@@ -112434,7 +126685,7 @@
       "JMP:REANIMATED (3)"
     ],
     "Zuko's Conviction": [
-      "TLA:BOUNTY-HUNTER (1)",
+      "TLA:BOUNTY HUNTER (1)",
       "TLA:NIGHTMARES"
     ],
     "Zuko's Exile": [
@@ -112451,15 +126702,15 @@
     "Zuko, Exiled Prince": [
       "TLA:FIREBENDING (1)",
       "TLA:FIREBENDING (2)",
-      "TLA:SPARKY-SPARKY (1)",
-      "TLA:SPARKY-SPARKY (2)",
+      "TLA:SPARKY SPARKY (1)",
+      "TLA:SPARKY SPARKY (2)",
       "TLB:FIREBENDING"
     ],
     "Zuko, Firebending Master": [
       "TLA:ZUKO"
     ],
     "Zuko, Seeking Honor": [
-      "TLA:FIRE-NATION",
+      "TLA:FIRE NATION",
       "TLA:IROH",
       "TLA:REBELLING (1)",
       "TLA:REBELLING (2)",

--- a/etc/parsing-scripts/generate_combined_json.py
+++ b/etc/parsing-scripts/generate_combined_json.py
@@ -71,6 +71,7 @@ def load_all_decks():
                 "set": set_code,
                 "set_name": SET_NAMES.get(set_code, set_code),
                 "deck_name": deck_name,
+                "tokens": deck_data.get("tokens", []),
                 "cards": deck_data["cards"]
             }
 


### PR DESCRIPTION
- generate_combined_json.py: include tokens field from individual deck JSONs
- Regenerated jumpstart-decks-combined.json: 529 decks, 379 with token data, TLA deck names no longer hyphenated