### PR TITLE
Add token data to all deck JSONs with consolidated token index

### DIFF
--- a/etc/BRO/INFANTRY (1).json
+++ b/etc/BRO/INFANTRY (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     }
   ],
   "cards": [
@@ -154,7 +156,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/INFANTRY (2).json
+++ b/etc/BRO/INFANTRY (2).json
@@ -5,14 +5,18 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     },
     {
       "name": "Soldier",
       "type_line": "Token Artifact Creature — Soldier",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
     }
   ],
   "cards": [
@@ -103,7 +107,9 @@
           "type_line": "Token Artifact Creature — Soldier",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
         }
       ]
     },
@@ -170,7 +176,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/POWERSTONES (1).json
+++ b/etc/BRO/POWERSTONES (1).json
@@ -5,14 +5,20 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     },
     {
       "name": "Thopter",
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -33,7 +39,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -70,7 +78,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -91,7 +103,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -136,7 +150,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -155,7 +171,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/POWERSTONES (2).json
+++ b/etc/BRO/POWERSTONES (2).json
@@ -5,14 +5,20 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     },
     {
       "name": "Thopter",
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -33,7 +39,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -70,7 +78,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -91,7 +103,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -136,7 +150,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -167,7 +183,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/TITANIC (1).json
+++ b/etc/BRO/TITANIC (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/UNEARTHED (2).json
+++ b/etc/BRO/UNEARTHED (2).json
@@ -7,7 +7,9 @@
       "type_line": "Token Artifact Creature — Zombie",
       "colors": [],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "82868a85-a6f4-47db-b159-d23a9c4c9892"
     }
   ],
   "cards": [
@@ -152,7 +154,9 @@
           "type_line": "Token Artifact Creature — Zombie",
           "colors": [],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "82868a85-a6f4-47db-b159-d23a9c4c9892"
         }
       ]
     },

--- a/etc/BRO/WELDED (1).json
+++ b/etc/BRO/WELDED (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },

--- a/etc/BRO/WELDED (2).json
+++ b/etc/BRO/WELDED (2).json
@@ -5,14 +5,18 @@
     {
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
     },
     {
       "name": "Soldier",
       "type_line": "Token Artifact Creature — Soldier",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
     }
   ],
   "cards": [
@@ -33,7 +37,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -128,7 +134,9 @@
         {
           "name": "Powerstone",
           "type_line": "Token Artifact — Powerstone",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
         }
       ]
     },
@@ -149,7 +157,9 @@
           "type_line": "Token Artifact Creature — Soldier",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
         }
       ]
     },

--- a/etc/CLU/AZORIUS SENATE 1.json
+++ b/etc/CLU/AZORIUS SENATE 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -126,7 +128,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/CLU/AZORIUS SENATE 2.json
+++ b/etc/CLU/AZORIUS SENATE 2.json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/CLU/BOROS LEGION 1.json
+++ b/etc/CLU/BOROS LEGION 1.json
@@ -9,12 +9,19 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Soldier",
@@ -23,7 +30,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "01e023e5-38bc-4203-aecb-6b2de54b03ea"
     }
   ],
   "cards": [
@@ -44,7 +55,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -139,7 +152,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "01e023e5-38bc-4203-aecb-6b2de54b03ea"
         },
         {
           "name": "Angel",
@@ -148,7 +165,12 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying",
+            "Vigilance"
+          ],
+          "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
         }
       ]
     },

--- a/etc/CLU/BOROS LEGION 2.json
+++ b/etc/CLU/BOROS LEGION 2.json
@@ -9,12 +9,16 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -152,7 +156,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -196,7 +202,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/CLU/CULT OF RAKDOS 1.json
+++ b/etc/CLU/CULT OF RAKDOS 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -138,7 +140,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/CLU/CULT OF RAKDOS 2.json
+++ b/etc/CLU/CULT OF RAKDOS 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -113,7 +115,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/CLU/GOLGARI SWARM 1.json
+++ b/etc/CLU/GOLGARI SWARM 1.json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794"
     },
     {
       "name": "Insect",
@@ -19,7 +23,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "ea029c48-d26e-40b1-acef-2ec47fb61101"
     },
     {
       "name": "Saproling",
@@ -28,7 +34,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -68,7 +76,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794"
         }
       ]
     },
@@ -108,7 +120,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -164,7 +178,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "ea029c48-d26e-40b1-acef-2ec47fb61101"
         }
       ]
     },

--- a/etc/CLU/GOLGARI SWARM 2.json
+++ b/etc/CLU/GOLGARI SWARM 2.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -92,7 +94,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -184,7 +188,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/CLU/GRUUL CLANS 1.json
+++ b/etc/CLU/GRUUL CLANS 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -174,7 +176,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/CLU/GRUUL CLANS 2.json
+++ b/etc/CLU/GRUUL CLANS 2.json
@@ -9,12 +9,16 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "11734409-b03b-4905-af83-261f29a96bc2"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -125,7 +129,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "11734409-b03b-4905-af83-261f29a96bc2"
         }
       ]
     },
@@ -146,7 +152,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/CLU/IZZET LEAGUE 1.json
+++ b/etc/CLU/IZZET LEAGUE 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -99,7 +101,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/CLU/IZZET LEAGUE 2.json
+++ b/etc/CLU/IZZET LEAGUE 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Goblin Wizard",
@@ -14,7 +16,11 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692"
     }
   ],
   "cards": [
@@ -133,7 +139,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -156,7 +164,11 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Prowess"
+          ],
+          "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692"
         }
       ]
     },

--- a/etc/CLU/ORZHOV SYNDICATE 1.json
+++ b/etc/CLU/ORZHOV SYNDICATE 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Spirit",
@@ -15,7 +17,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
     }
   ],
   "cards": [
@@ -112,7 +118,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
         }
       ]
     },
@@ -148,7 +158,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -197,7 +209,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
         }
       ]
     },

--- a/etc/CLU/ORZHOV SYNDICATE 2.json
+++ b/etc/CLU/ORZHOV SYNDICATE 2.json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794"
     },
     {
       "name": "Spirit",
@@ -19,12 +23,18 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -78,7 +88,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794"
         }
       ]
     },
@@ -132,7 +146,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
         }
       ]
     },
@@ -159,7 +177,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
         }
       ]
     },
@@ -179,7 +201,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -204,7 +228,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
         }
       ]
     },

--- a/etc/CLU/SELESNYA CONCLAVE 1.json
+++ b/etc/CLU/SELESNYA CONCLAVE 1.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Bird",
@@ -18,12 +22,18 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Saproling",
@@ -32,7 +42,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     },
     {
       "name": "Soldier",
@@ -41,7 +53,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
     },
     {
       "name": "Spirit",
@@ -50,7 +66,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -75,7 +95,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -115,7 +139,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -140,7 +166,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },
@@ -162,7 +192,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -187,7 +219,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },
@@ -209,7 +245,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -235,7 +273,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
         }
       ]
     },

--- a/etc/CLU/SELESNYA CONCLAVE 2.json
+++ b/etc/CLU/SELESNYA CONCLAVE 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Elemental",
@@ -15,7 +17,9 @@
         "W"
       ],
       "power": "*",
-      "toughness": "*"
+      "toughness": "*",
+      "keywords": [],
+      "oracle_id": "9f790267-5be9-41aa-be69-f87a8ce5a29e"
     },
     {
       "name": "Saproling",
@@ -24,7 +28,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     },
     {
       "name": "Spirit",
@@ -33,7 +39,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -58,7 +68,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -99,7 +113,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -135,7 +151,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -176,7 +194,9 @@
             "W"
           ],
           "power": "*",
-          "toughness": "*"
+          "toughness": "*",
+          "keywords": [],
+          "oracle_id": "9f790267-5be9-41aa-be69-f87a8ce5a29e"
         }
       ]
     },

--- a/etc/CLU/SIMIC COMBINE 1.json
+++ b/etc/CLU/SIMIC COMBINE 1.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
     }
   ],
   "cards": [
@@ -159,7 +161,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
         }
       ]
     },

--- a/etc/CLU/SIMIC COMBINE 2.json
+++ b/etc/CLU/SIMIC COMBINE 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Frog Lizard",
@@ -14,7 +16,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
     }
   ],
   "cards": [
@@ -136,7 +140,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -175,7 +181,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
         }
       ]
     },

--- a/etc/DMU/COALITION CORPS.json
+++ b/etc/DMU/COALITION CORPS.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     },
     {
       "name": "Soldier",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -57,7 +63,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -82,7 +90,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -161,7 +171,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -208,7 +220,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/DMU/COALITION LEGION.json
+++ b/etc/DMU/COALITION LEGION.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     },
     {
       "name": "Soldier",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -85,7 +91,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -186,7 +194,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/DMU/MONSTER TERRITORY.json
+++ b/etc/DMU/MONSTER TERRITORY.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -166,7 +168,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/FDN/CATS.json
+++ b/etc/FDN/CATS.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
         }
       ]
     },

--- a/etc/FDN/ELVES.json
+++ b/etc/FDN/ELVES.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/FDN/GOBLINS.json
+++ b/etc/FDN/GOBLINS.json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -142,7 +144,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/FDN/INFERNO.json
+++ b/etc/FDN/INFERNO.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -96,7 +98,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -129,7 +133,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/FDN/PIRATES.json
+++ b/etc/FDN/PIRATES.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/FDN/UNDEAD.json
+++ b/etc/FDN/UNDEAD.json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -143,7 +147,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/FDN/WIZARDS.json
+++ b/etc/FDN/WIZARDS.json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
     }
   ],
   "cards": [
@@ -90,7 +94,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
         }
       ]
     },

--- a/etc/J22/BLINK (1).json
+++ b/etc/J22/BLINK (1).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Knight",
@@ -19,7 +23,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -68,7 +76,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -117,7 +127,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -142,7 +154,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/J22/BLINK (2).json
+++ b/etc/J22/BLINK (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -118,7 +122,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/J22/BLINK (3).json
+++ b/etc/J22/BLINK (3).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Knight",
@@ -14,7 +16,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -49,7 +55,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -130,7 +138,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/J22/BLINK (4).json
+++ b/etc/J22/BLINK (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -116,7 +120,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/J22/BONEYARD (1).json
+++ b/etc/J22/BONEYARD (1).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/BONEYARD (2).json
+++ b/etc/J22/BONEYARD (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/CATS (1).json
+++ b/etc/J22/CATS (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
         }
       ]
     },

--- a/etc/J22/CATS (2).json
+++ b/etc/J22/CATS (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "8050907b-4007-4478-8ebd-25b8b2bf85c3"
     }
   ],
   "cards": [
@@ -168,7 +170,9 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "8050907b-4007-4478-8ebd-25b8b2bf85c3"
         }
       ]
     },

--- a/etc/J22/CATS (3).json
+++ b/etc/J22/CATS (3).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "9fcff433-c6f7-44c6-8279-04625703cb3e"
     }
   ],
   "cards": [
@@ -177,7 +179,9 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "9fcff433-c6f7-44c6-8279-04625703cb3e"
         }
       ]
     },

--- a/etc/J22/CATS (4).json
+++ b/etc/J22/CATS (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
         }
       ]
     },

--- a/etc/J22/CONSTELLATION (1).json
+++ b/etc/J22/CONSTELLATION (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d"
         }
       ]
     },

--- a/etc/J22/CONSTELLATION (2).json
+++ b/etc/J22/CONSTELLATION (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },

--- a/etc/J22/CYCLING (2).json
+++ b/etc/J22/CYCLING (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
         }
       ]
     },

--- a/etc/J22/DEMONS (2).json
+++ b/etc/J22/DEMONS (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/DETECTIVE (1).json
+++ b/etc/J22/DETECTIVE (1).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -55,7 +59,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -76,7 +82,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -111,7 +119,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -144,7 +154,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -163,7 +175,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -180,7 +194,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -199,7 +215,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -218,7 +236,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/J22/DETECTIVE (2).json
+++ b/etc/J22/DETECTIVE (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -66,7 +68,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -115,7 +119,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -134,7 +140,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -153,7 +161,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -180,7 +190,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -199,7 +211,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/J22/DETECTIVE (3).json
+++ b/etc/J22/DETECTIVE (3).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -71,7 +75,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -92,7 +98,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -127,7 +135,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -160,7 +170,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -179,7 +191,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -196,7 +210,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -215,7 +231,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/J22/DETECTIVE (4).json
+++ b/etc/J22/DETECTIVE (4).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -64,7 +70,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -85,7 +93,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -120,7 +130,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -139,7 +151,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -158,7 +172,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -175,7 +191,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -192,7 +210,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -211,7 +231,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/J22/DRAGONS (1).json
+++ b/etc/J22/DRAGONS (1).json
@@ -9,7 +9,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ec6df381-5ea7-4c68-8416-093b107f0784"
     },
     {
       "name": "Goblin",
@@ -18,7 +22,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -57,7 +63,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ec6df381-5ea7-4c68-8416-093b107f0784"
         }
       ]
     },
@@ -150,7 +160,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/DRAGONS (2).json
+++ b/etc/J22/DRAGONS (2).json
@@ -9,7 +9,11 @@
         "R"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "R"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
         }
       ]
     },

--- a/etc/J22/ELDRAZI.json
+++ b/etc/J22/ELDRAZI.json
@@ -7,7 +7,9 @@
       "type_line": "Token Creature — Eldrazi Scion",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
     }
   ],
   "cards": [
@@ -52,7 +54,9 @@
           "type_line": "Token Creature — Eldrazi Scion",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
         }
       ]
     },
@@ -73,7 +77,9 @@
           "type_line": "Token Creature — Eldrazi Scion",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
         }
       ]
     },
@@ -106,7 +112,9 @@
           "type_line": "Token Creature — Eldrazi Scion",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
         }
       ]
     },

--- a/etc/J22/ELVES (1).json
+++ b/etc/J22/ELVES (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -154,7 +160,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -213,7 +221,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J22/ELVES (2).json
+++ b/etc/J22/ELVES (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -154,7 +160,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -213,7 +221,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J22/ELVES (3).json
+++ b/etc/J22/ELVES (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -126,7 +132,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -151,7 +159,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -210,7 +220,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J22/ELVES (4).json
+++ b/etc/J22/ELVES (4).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Elf Warrior",
@@ -14,7 +16,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -67,7 +71,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -100,7 +106,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -139,7 +147,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -198,7 +208,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -221,7 +233,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J22/EXPERIMENTAL (1).json
+++ b/etc/J22/EXPERIMENTAL (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Elemental",
@@ -14,7 +16,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     }
   ],
   "cards": [
@@ -39,7 +43,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },
@@ -88,7 +94,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -165,7 +173,11 @@
             "R"
           ],
           "power": "*",
-          "toughness": "*"
+          "toughness": "*",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "74a3dea1-6a43-4cd2-925e-0abcf076bd02"
         }
       ]
     },

--- a/etc/J22/EXPERIMENTAL (2).json
+++ b/etc/J22/EXPERIMENTAL (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -54,7 +56,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/J22/FAERIES (2).json
+++ b/etc/J22/FAERIES (2).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
         }
       ]
     },

--- a/etc/J22/FANGS (3).json
+++ b/etc/J22/FANGS (3).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "*",
-      "toughness": "*"
+      "toughness": "*",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0f6d78a4-f330-47b5-9c30-51324a1e7fb9"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "B"
           ],
           "power": "*",
-          "toughness": "*"
+          "toughness": "*",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0f6d78a4-f330-47b5-9c30-51324a1e7fb9"
         }
       ]
     },

--- a/etc/J22/FIERY (3).json
+++ b/etc/J22/FIERY (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
     }
   ],
   "cards": [
@@ -140,7 +142,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
         }
       ]
     },

--- a/etc/J22/GO TO SCHOOL (1).json
+++ b/etc/J22/GO TO SCHOOL (1).json
@@ -9,7 +9,9 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f"
     }
   ],
   "cards": [
@@ -181,7 +183,9 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f"
         }
       ]
     },

--- a/etc/J22/GO TO SCHOOL (2).json
+++ b/etc/J22/GO TO SCHOOL (2).json
@@ -10,7 +10,9 @@
         "U"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [],
+      "oracle_id": "f81c047d-de36-4aed-806b-f14a290771a4"
     },
     {
       "name": "Wizard",
@@ -19,7 +21,9 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f"
     }
   ],
   "cards": [
@@ -139,7 +143,9 @@
             "U"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [],
+          "oracle_id": "f81c047d-de36-4aed-806b-f14a290771a4"
         }
       ]
     },
@@ -199,7 +205,9 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f"
         }
       ]
     },

--- a/etc/J22/GOBLINS (1).json
+++ b/etc/J22/GOBLINS (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -141,7 +145,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -176,7 +182,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/GOBLINS (2).json
+++ b/etc/J22/GOBLINS (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -141,7 +145,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -176,7 +182,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/GOBLINS (3).json
+++ b/etc/J22/GOBLINS (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -142,7 +144,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/GOBLINS (4).json
+++ b/etc/J22/GOBLINS (4).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -138,7 +144,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -161,7 +169,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -196,7 +206,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/GROSS (2).json
+++ b/etc/J22/GROSS (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -167,7 +171,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J22/GROSS (4).json
+++ b/etc/J22/GROSS (4).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Deathtouch"
+      ],
+      "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Deathtouch"
+          ],
+          "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
         }
       ]
     },

--- a/etc/J22/HOLY (3).json
+++ b/etc/J22/HOLY (3).json
@@ -9,7 +9,12 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
     },
     {
       "name": "Soldier",
@@ -18,7 +23,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
     }
   ],
   "cards": [
@@ -43,7 +52,12 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying",
+            "Vigilance"
+          ],
+          "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
         }
       ]
     },
@@ -184,7 +198,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
         }
       ]
     },

--- a/etc/J22/HOLY (4).json
+++ b/etc/J22/HOLY (4).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
         }
       ]
     },

--- a/etc/J22/INSECTS (1).json
+++ b/etc/J22/INSECTS (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },
@@ -87,7 +91,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },
@@ -204,7 +210,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },

--- a/etc/J22/INSECTS (2).json
+++ b/etc/J22/INSECTS (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
     }
   ],
   "cards": [
@@ -180,7 +182,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },

--- a/etc/J22/INSECTS (3).json
+++ b/etc/J22/INSECTS (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },
@@ -193,7 +197,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },

--- a/etc/J22/INSECTS (4).json
+++ b/etc/J22/INSECTS (4).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "5e34ad53-c154-4302-b25a-fe4bb1555a5f"
     },
     {
       "name": "Insect",
@@ -18,7 +22,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
     }
   ],
   "cards": [
@@ -141,7 +147,11 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "5e34ad53-c154-4302-b25a-fe4bb1555a5f"
         }
       ]
     },
@@ -200,7 +210,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
         }
       ]
     },

--- a/etc/J22/INVENTIVE (1).json
+++ b/etc/J22/INVENTIVE (1).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -30,7 +34,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -95,7 +103,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -142,7 +154,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -206,7 +222,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J22/INVENTIVE (2).json
+++ b/etc/J22/INVENTIVE (2).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -28,7 +32,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -51,7 +59,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -128,7 +140,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -163,7 +179,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J22/INVENTIVE (3).json
+++ b/etc/J22/INVENTIVE (3).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -42,7 +46,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -91,7 +99,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -138,7 +150,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -169,7 +185,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -210,7 +230,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J22/INVENTIVE (4).json
+++ b/etc/J22/INVENTIVE (4).json
@@ -5,14 +5,20 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Thopter",
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -47,7 +53,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -66,7 +76,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -85,7 +97,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -122,7 +136,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -181,7 +199,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J22/KNIGHTS.json
+++ b/etc/J22/KNIGHTS.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/J22/LANDFALL (1).json
+++ b/etc/J22/LANDFALL (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [],
+      "oracle_id": "695b14a0-920a-47bd-bd4a-7989862cdd0a"
     },
     {
       "name": "Elemental",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
     }
   ],
   "cards": [
@@ -85,7 +89,9 @@
             "G"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [],
+          "oracle_id": "695b14a0-920a-47bd-bd4a-7989862cdd0a"
         }
       ]
     },
@@ -184,7 +190,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
         }
       ]
     },

--- a/etc/J22/LANDFALL (2).json
+++ b/etc/J22/LANDFALL (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "0",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "bcd346a7-4d96-4a0c-9725-fb740e32b730"
     }
   ],
   "cards": [
@@ -90,7 +92,9 @@
             "G"
           ],
           "power": "0",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "bcd346a7-4d96-4a0c-9725-fb740e32b730"
         }
       ]
     },

--- a/etc/J22/LAW (2).json
+++ b/etc/J22/LAW (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Soldier",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -139,7 +145,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         },
         {
           "name": "Soldier",
@@ -148,7 +158,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/J22/LAW (4).json
+++ b/etc/J22/LAW (4).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -178,7 +180,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/J22/MERFOLK (1).json
+++ b/etc/J22/MERFOLK (1).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Hexproof"
+      ],
+      "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c"
     }
   ],
   "cards": [
@@ -168,7 +172,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Hexproof"
+          ],
+          "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c"
         }
       ]
     },

--- a/etc/J22/MERFOLK (4).json
+++ b/etc/J22/MERFOLK (4).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Hexproof"
+      ],
+      "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c"
     }
   ],
   "cards": [
@@ -168,7 +172,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Hexproof"
+          ],
+          "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c"
         }
       ]
     },

--- a/etc/J22/MORBID (1).json
+++ b/etc/J22/MORBID (1).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/MORBID (2).json
+++ b/etc/J22/MORBID (2).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
     },
     {
       "name": "Zombie",
@@ -18,7 +22,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -57,7 +63,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -82,7 +90,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -107,7 +117,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },
@@ -132,7 +146,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },

--- a/etc/J22/RAID (1).json
+++ b/etc/J22/RAID (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "e2a98673-a9c2-4579-b962-080405bbb661"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "e2a98673-a9c2-4579-b962-080405bbb661"
         }
       ]
     },

--- a/etc/J22/RATS.json
+++ b/etc/J22/RATS.json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
         }
       ]
     },

--- a/etc/J22/SNOW.json
+++ b/etc/J22/SNOW.json
@@ -9,7 +9,12 @@
         "B"
       ],
       "power": "20",
-      "toughness": "20"
+      "toughness": "20",
+      "keywords": [
+        "Flying",
+        "Indestructible"
+      ],
+      "oracle_id": "48e9147e-59f7-4693-83d7-7f514be871bc"
     }
   ],
   "cards": [
@@ -162,7 +167,12 @@
             "B"
           ],
           "power": "20",
-          "toughness": "20"
+          "toughness": "20",
+          "keywords": [
+            "Flying",
+            "Indestructible"
+          ],
+          "oracle_id": "48e9147e-59f7-4693-83d7-7f514be871bc"
         }
       ]
     },

--- a/etc/J22/SPEEDY.json
+++ b/etc/J22/SPEEDY.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Goblin",
@@ -14,7 +16,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -63,7 +67,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -88,7 +94,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/SPIRITS (1).json
+++ b/etc/J22/SPIRITS (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -101,7 +109,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -166,7 +178,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -189,7 +205,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },

--- a/etc/J22/SPIRITS (2).json
+++ b/etc/J22/SPIRITS (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -73,7 +81,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -152,7 +164,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -199,7 +215,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },

--- a/etc/J22/THINK AGAIN (2).json
+++ b/etc/J22/THINK AGAIN (2).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/J22/THINK AGAIN (3).json
+++ b/etc/J22/THINK AGAIN (3).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/J22/THINK AGAIN (4).json
+++ b/etc/J22/THINK AGAIN (4).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
         }
       ]
     },

--- a/etc/J22/TREASURE (1).json
+++ b/etc/J22/TREASURE (1).json
@@ -9,17 +9,25 @@
         "R"
       ],
       "power": "3",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Haste"
+      ],
+      "oracle_id": "74658c70-caa8-4172-8a65-055d327668f9"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -40,7 +48,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -65,7 +75,11 @@
             "R"
           ],
           "power": "3",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Haste"
+          ],
+          "oracle_id": "74658c70-caa8-4172-8a65-055d327668f9"
         }
       ]
     },
@@ -100,7 +114,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -133,7 +149,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -154,7 +172,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -187,7 +207,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -216,7 +238,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -235,7 +259,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J22/TREASURE (2).json
+++ b/etc/J22/TREASURE (2).json
@@ -5,12 +5,16 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -80,7 +86,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -141,7 +149,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -162,7 +172,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -181,7 +193,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -210,7 +224,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J22/TREASURE (3).json
+++ b/etc/J22/TREASURE (3).json
@@ -5,12 +5,16 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -66,7 +72,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -115,7 +123,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -134,7 +144,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -155,7 +167,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -198,7 +212,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -215,7 +231,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J22/TREASURE (4).json
+++ b/etc/J22/TREASURE (4).json
@@ -5,12 +5,16 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -66,7 +72,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -113,7 +121,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -132,7 +142,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -153,7 +165,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -172,7 +186,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -201,7 +217,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -220,7 +238,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J22/UNLUCKY THIRTEEN.json
+++ b/etc/J22/UNLUCKY THIRTEEN.json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J22/URZA'S.json
+++ b/etc/J22/URZA'S.json
@@ -7,7 +7,9 @@
       "type_line": "Token Artifact Creature — Assembly-Worker",
       "colors": [],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "02e1a471-36b2-4d28-a323-f4ec3d095cb9"
     }
   ],
   "cards": [
@@ -161,7 +163,9 @@
           "type_line": "Token Artifact Creature — Assembly-Worker",
           "colors": [],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "02e1a471-36b2-4d28-a323-f4ec3d095cb9"
         }
       ]
     },

--- a/etc/J22/WOLVES (1).json
+++ b/etc/J22/WOLVES (1).json
@@ -9,12 +9,18 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Food"
+      ],
+      "oracle_id": "a6f7f5c7-8832-40f8-803e-f181571422f8"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Wolf",
@@ -23,7 +29,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -90,7 +98,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -125,7 +135,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -162,7 +174,11 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Food"
+          ],
+          "oracle_id": "a6f7f5c7-8832-40f8-803e-f181571422f8"
         }
       ]
     },
@@ -197,7 +213,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -220,7 +238,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -244,7 +264,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },

--- a/etc/J22/WOLVES (2).json
+++ b/etc/J22/WOLVES (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -203,7 +209,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },

--- a/etc/J22/WOLVES (3).json
+++ b/etc/J22/WOLVES (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -87,7 +91,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -150,7 +156,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -185,7 +193,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -208,7 +218,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -232,7 +244,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },

--- a/etc/J22/WOLVES (4).json
+++ b/etc/J22/WOLVES (4).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -101,7 +105,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -178,7 +184,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -214,7 +222,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },

--- a/etc/J22/ZOMBIES (1).json
+++ b/etc/J22/ZOMBIES (1).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -90,7 +92,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -143,7 +147,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -190,7 +196,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/ZOMBIES (2).json
+++ b/etc/J22/ZOMBIES (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -143,7 +147,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -203,7 +209,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/ZOMBIES (3).json
+++ b/etc/J22/ZOMBIES (3).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -176,7 +182,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -199,7 +207,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J22/ZOMBIES (4).json
+++ b/etc/J22/ZOMBIES (4).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -174,7 +180,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -197,7 +205,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J25/ARMED (1).json
+++ b/etc/J25/ARMED (1).json
@@ -9,7 +9,12 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
     },
     {
       "name": "Rebel",
@@ -18,7 +23,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     },
     {
       "name": "Soldier",
@@ -27,7 +34,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -154,7 +163,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -177,7 +188,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -200,7 +213,12 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying",
+            "Vigilance"
+          ],
+          "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
         }
       ]
     },

--- a/etc/J25/ARMED (2).json
+++ b/etc/J25/ARMED (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -147,7 +151,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -170,7 +176,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -193,7 +201,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },

--- a/etc/J25/ARMED (3).json
+++ b/etc/J25/ARMED (3).json
@@ -9,7 +9,12 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
     },
     {
       "name": "Rebel",
@@ -18,7 +23,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     },
     {
       "name": "Soldier",
@@ -27,7 +34,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -158,7 +167,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -181,7 +192,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -204,7 +217,12 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying",
+            "Vigilance"
+          ],
+          "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
         }
       ]
     },

--- a/etc/J25/ARMED (4).json
+++ b/etc/J25/ARMED (4).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -161,7 +165,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -184,7 +190,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },

--- a/etc/J25/BLOODY (1).json
+++ b/etc/J25/BLOODY (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -82,7 +88,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -103,7 +111,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -152,7 +162,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/BLOODY (2).json
+++ b/etc/J25/BLOODY (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -96,7 +102,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -117,7 +125,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/BLOODY (3).json
+++ b/etc/J25/BLOODY (3).json
@@ -5,12 +5,16 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -52,7 +58,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -73,7 +81,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -94,7 +104,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -115,7 +127,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/BLOODY (4).json
+++ b/etc/J25/BLOODY (4).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -82,7 +88,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -103,7 +111,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -152,7 +162,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/BOOKWORMS (3).json
+++ b/etc/J25/BOOKWORMS (3).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -114,7 +118,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J25/BOOKWORMS (4).json
+++ b/etc/J25/BOOKWORMS (4).json
@@ -9,7 +9,9 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "82adaeee-e011-49db-af53-fda6c2b192d5"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "82adaeee-e011-49db-af53-fda6c2b192d5"
         }
       ]
     },

--- a/etc/J25/BURNING.json
+++ b/etc/J25/BURNING.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/J25/CLERICS (1).json
+++ b/etc/J25/CLERICS (1).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },

--- a/etc/J25/CLERICS (2).json
+++ b/etc/J25/CLERICS (2).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },

--- a/etc/J25/CLERICS (4).json
+++ b/etc/J25/CLERICS (4).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
     }
   ],
   "cards": [
@@ -90,7 +94,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },

--- a/etc/J25/COPIED (1).json
+++ b/etc/J25/COPIED (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },

--- a/etc/J25/COPIED (2).json
+++ b/etc/J25/COPIED (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },

--- a/etc/J25/DINNER.json
+++ b/etc/J25/DINNER.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Giant",
@@ -14,7 +16,9 @@
         "G"
       ],
       "power": "7",
-      "toughness": "7"
+      "toughness": "7",
+      "keywords": [],
+      "oracle_id": "33ec3894-6ec2-4038-bed4-85e5b9cfe182"
     },
     {
       "name": "Saproling",
@@ -23,12 +27,16 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -49,7 +57,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -74,7 +84,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -95,7 +107,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -130,7 +144,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -151,12 +167,16 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         },
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -177,7 +197,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -212,12 +234,16 @@
             "G"
           ],
           "power": "7",
-          "toughness": "7"
+          "toughness": "7",
+          "keywords": [],
+          "oracle_id": "33ec3894-6ec2-4038-bed4-85e5b9cfe182"
         },
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -260,7 +286,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/J25/DINOSAURS (1).json
+++ b/etc/J25/DINOSAURS (1).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "240300bd-5088-43c5-a873-290507515843"
     },
     {
       "name": "Saproling",
@@ -18,7 +22,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -57,7 +63,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -152,7 +160,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "240300bd-5088-43c5-a873-290507515843"
         }
       ]
     },

--- a/etc/J25/DINOSAURS (2).json
+++ b/etc/J25/DINOSAURS (2).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "240300bd-5088-43c5-a873-290507515843"
     },
     {
       "name": "Saproling",
@@ -18,7 +22,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -71,7 +77,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -152,7 +160,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "240300bd-5088-43c5-a873-290507515843"
         }
       ]
     },

--- a/etc/J25/DRAGONS (1).json
+++ b/etc/J25/DRAGONS (1).json
@@ -9,12 +9,18 @@
         "R"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -39,7 +45,11 @@
             "R"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
         }
       ]
     },
@@ -116,7 +126,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -149,7 +161,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/DRAGONS (2).json
+++ b/etc/J25/DRAGONS (2).json
@@ -9,12 +9,18 @@
         "R"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -39,7 +45,11 @@
             "R"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
         }
       ]
     },
@@ -142,7 +152,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -190,7 +202,11 @@
             "R"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
         }
       ]
     },

--- a/etc/J25/DROWNED (1).json
+++ b/etc/J25/DROWNED (1).json
@@ -9,7 +9,9 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0"
         }
       ]
     },

--- a/etc/J25/DROWNED (2).json
+++ b/etc/J25/DROWNED (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Fish",
@@ -14,7 +16,9 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0"
     }
   ],
   "cards": [
@@ -81,7 +85,9 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0"
         }
       ]
     },
@@ -168,7 +174,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/J25/ELVES (2).json
+++ b/etc/J25/ELVES (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J25/ELVES (3).json
+++ b/etc/J25/ELVES (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -90,7 +92,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J25/ELVES (4).json
+++ b/etc/J25/ELVES (4).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "7",
-      "toughness": "7"
+      "toughness": "7",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "ab19c684-94c6-4491-8a6b-7f31dddadae6"
     },
     {
       "name": "Elf Warrior",
@@ -18,7 +22,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -43,7 +49,11 @@
             "G"
           ],
           "power": "7",
-          "toughness": "7"
+          "toughness": "7",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "ab19c684-94c6-4491-8a6b-7f31dddadae6"
         }
       ]
     },
@@ -201,7 +211,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/J25/ENCHANTED (2).json
+++ b/etc/J25/ENCHANTED (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "4bd91cb2-be86-4950-8b84-7b330a8a61b9"
     }
   ],
   "cards": [
@@ -168,7 +172,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "4bd91cb2-be86-4950-8b84-7b330a8a61b9"
         }
       ]
     },

--- a/etc/J25/ENCHANTED (4).json
+++ b/etc/J25/ENCHANTED (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d"
         }
       ]
     },

--- a/etc/J25/ENCOUNTER (2).json
+++ b/etc/J25/ENCOUNTER (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J25/ENCOUNTER (3).json
+++ b/etc/J25/ENCOUNTER (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J25/ENCOUNTER (4).json
+++ b/etc/J25/ENCOUNTER (4).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
     }
   ],
   "cards": [
@@ -168,7 +170,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         }
       ]
     },

--- a/etc/J25/EXPLORERS (1).json
+++ b/etc/J25/EXPLORERS (1).json
@@ -5,12 +5,16 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -127,12 +131,16 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         },
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/J25/EXPLORERS (2).json
+++ b/etc/J25/EXPLORERS (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Human Soldier",
@@ -14,7 +16,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -35,7 +39,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -124,7 +130,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -193,7 +201,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         },
         {
           "name": "Human Soldier",
@@ -202,7 +212,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/J25/EXPLORERS (3).json
+++ b/etc/J25/EXPLORERS (3).json
@@ -9,12 +9,16 @@
         "G"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Elf Warrior",
@@ -23,7 +27,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     },
     {
       "name": "Human Soldier",
@@ -32,7 +38,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     },
     {
       "name": "Wolf",
@@ -41,7 +49,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -62,7 +72,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -87,7 +99,9 @@
             "G"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         },
         {
           "name": "Beast",
@@ -96,7 +110,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         },
         {
           "name": "Wolf",
@@ -105,7 +121,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },
@@ -170,7 +188,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -191,7 +211,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -260,7 +282,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         },
         {
           "name": "Human Soldier",
@@ -269,7 +293,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/J25/FUN GUYS (1).json
+++ b/etc/J25/FUN GUYS (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -126,7 +132,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -161,7 +169,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -208,7 +218,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -231,7 +243,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J25/FUN GUYS (2).json
+++ b/etc/J25/FUN GUYS (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -84,7 +90,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -123,7 +131,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -172,7 +182,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -219,7 +231,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -242,7 +256,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J25/GHASTLY (1).json
+++ b/etc/J25/GHASTLY (1).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -164,7 +170,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J25/GHASTLY (2).json
+++ b/etc/J25/GHASTLY (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -153,7 +157,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J25/GHASTLY (3).json
+++ b/etc/J25/GHASTLY (3).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     },
     {
       "name": "Worm",
@@ -15,7 +17,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
     },
     {
       "name": "Zombie",
@@ -24,7 +28,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -64,7 +70,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
         }
       ]
     },
@@ -103,7 +111,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -190,7 +200,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/GHASTLY (4).json
+++ b/etc/J25/GHASTLY (4).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     },
     {
       "name": "Zombie",
@@ -14,7 +16,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -49,7 +53,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -74,7 +80,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -127,7 +135,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -150,7 +160,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -185,7 +197,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -204,7 +218,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/GIDDYAP.json
+++ b/etc/J25/GIDDYAP.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/J25/GOBLINS (1).json
+++ b/etc/J25/GOBLINS (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -152,7 +158,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -175,7 +183,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J25/GOBLINS (2).json
+++ b/etc/J25/GOBLINS (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -98,7 +104,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -163,7 +171,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -186,7 +196,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J25/GOBLINS (3).json
+++ b/etc/J25/GOBLINS (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -84,7 +90,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -163,7 +171,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -186,7 +196,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J25/GOBLINS (4).json
+++ b/etc/J25/GOBLINS (4).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -59,7 +63,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -84,7 +90,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -163,7 +171,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -186,7 +196,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J25/GRAVE ROBBERS (2).json
+++ b/etc/J25/GRAVE ROBBERS (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -160,7 +162,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/GRAVE ROBBERS (3).json
+++ b/etc/J25/GRAVE ROBBERS (3).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J25/GRAVE ROBBERS (4).json
+++ b/etc/J25/GRAVE ROBBERS (4).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -179,7 +181,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/J25/HEALERS (1).json
+++ b/etc/J25/HEALERS (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },

--- a/etc/J25/HEALERS (2).json
+++ b/etc/J25/HEALERS (2).json
@@ -9,7 +9,12 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
     }
   ],
   "cards": [
@@ -34,7 +39,12 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying",
+            "Vigilance"
+          ],
+          "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
         }
       ]
     },

--- a/etc/J25/ICKY (1).json
+++ b/etc/J25/ICKY (1).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
     },
     {
       "name": "Worm",
@@ -19,7 +23,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
     }
   ],
   "cards": [
@@ -44,7 +50,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
         }
       ]
     },
@@ -70,7 +80,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
         }
       ]
     },

--- a/etc/J25/ICKY (2).json
+++ b/etc/J25/ICKY (2).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
     },
     {
       "name": "Worm",
@@ -19,7 +23,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
     }
   ],
   "cards": [
@@ -44,7 +50,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
         }
       ]
     },
@@ -84,7 +94,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
         }
       ]
     },

--- a/etc/J25/ILLUSIONS.json
+++ b/etc/J25/ILLUSIONS.json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "6c29dcc1-d7b6-4ef6-b663-0cc0e4be0529"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "6c29dcc1-d7b6-4ef6-b663-0cc0e4be0529"
         }
       ]
     },

--- a/etc/J25/INVENTIVE (1).json
+++ b/etc/J25/INVENTIVE (1).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -30,7 +34,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -79,7 +87,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -184,7 +196,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J25/INVENTIVE (2).json
+++ b/etc/J25/INVENTIVE (2).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -30,7 +34,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -93,7 +101,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J25/INVENTIVE (3).json
+++ b/etc/J25/INVENTIVE (3).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -84,7 +88,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J25/INVENTIVE (4).json
+++ b/etc/J25/INVENTIVE (4).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -82,7 +86,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },

--- a/etc/J25/LANDFALL (4).json
+++ b/etc/J25/LANDFALL (4).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/J25/LEGION (1).json
+++ b/etc/J25/LEGION (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -43,7 +47,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
         }
       ]
     },
@@ -150,7 +156,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -197,7 +205,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/J25/LEGION (2).json
+++ b/etc/J25/LEGION (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     },
     {
       "name": "Spirit",
@@ -27,7 +31,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -52,7 +60,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
         }
       ]
     },
@@ -145,7 +155,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -168,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -215,7 +231,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -248,7 +266,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/J25/MODIFIED.json
+++ b/etc/J25/MODIFIED.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     },
     {
       "name": "Wolf",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
     }
   ],
   "cards": [
@@ -57,7 +61,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },
@@ -172,7 +178,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
         }
       ]
     },

--- a/etc/J25/NER-DO-WELLS (1).json
+++ b/etc/J25/NER-DO-WELLS (1).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -148,7 +154,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -167,7 +175,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -198,7 +208,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/NER-DO-WELLS (2).json
+++ b/etc/J25/NER-DO-WELLS (2).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +35,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -148,7 +154,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -167,7 +175,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -186,7 +196,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -205,7 +217,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/NINJAS.json
+++ b/etc/J25/NINJAS.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -124,7 +126,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/PRIDEFUL.json
+++ b/etc/J25/PRIDEFUL.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "53c009a1-b9b6-43d6-8543-77688fedf8ae"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "53c009a1-b9b6-43d6-8543-77688fedf8ae"
         }
       ]
     },

--- a/etc/J25/SNAKES.json
+++ b/etc/J25/SNAKES.json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Deathtouch"
+      ],
+      "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Deathtouch"
+          ],
+          "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
         }
       ]
     },

--- a/etc/J25/SOARING (3).json
+++ b/etc/J25/SOARING (3).json
@@ -9,14 +9,22 @@
         "U"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "28cd830b-def6-4aa3-a0f6-6913bcdf931e"
     },
     {
       "name": "Thopter",
       "type_line": "Token Artifact Creature — Thopter",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
     }
   ],
   "cards": [
@@ -95,7 +103,11 @@
           "type_line": "Token Artifact Creature — Thopter",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
         }
       ]
     },
@@ -195,7 +207,11 @@
             "U"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "28cd830b-def6-4aa3-a0f6-6913bcdf931e"
         }
       ]
     },

--- a/etc/J25/SOARING (4).json
+++ b/etc/J25/SOARING (4).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
         }
       ]
     },

--- a/etc/J25/STALWART (1).json
+++ b/etc/J25/STALWART (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
     },
     {
       "name": "Spirit",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -113,7 +121,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },
@@ -201,7 +213,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
         }
       ]
     },

--- a/etc/J25/STALWART (2).json
+++ b/etc/J25/STALWART (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Spirit",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -43,7 +51,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },
@@ -124,7 +136,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },

--- a/etc/J25/STALWART (3).json
+++ b/etc/J25/STALWART (3).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     },
     {
       "name": "Vampire",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "97af46cb-6209-4ae7-81cc-792894999937"
     }
   ],
   "cards": [
@@ -113,7 +121,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Lifelink"
+          ],
+          "oracle_id": "97af46cb-6209-4ae7-81cc-792894999937"
         }
       ]
     },
@@ -152,7 +164,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },

--- a/etc/J25/STALWART (4).json
+++ b/etc/J25/STALWART (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
     }
   ],
   "cards": [
@@ -104,7 +108,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
         }
       ]
     },

--- a/etc/J25/STOKED (1).json
+++ b/etc/J25/STOKED (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
     }
   ],
   "cards": [
@@ -176,7 +178,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
         }
       ]
     },

--- a/etc/J25/STOKED (3).json
+++ b/etc/J25/STOKED (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
     }
   ],
   "cards": [
@@ -85,7 +89,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
         }
       ]
     },
@@ -124,7 +130,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },
@@ -207,7 +215,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
         }
       ]
     },

--- a/etc/J25/STOKED (4).json
+++ b/etc/J25/STOKED (4).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
     }
   ],
   "cards": [
@@ -71,7 +75,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
         }
       ]
     },
@@ -138,7 +144,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },

--- a/etc/J25/TOO MANY.json
+++ b/etc/J25/TOO MANY.json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -102,7 +104,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -161,7 +165,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/J25/TREASURES (1).json
+++ b/etc/J25/TREASURES (1).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -49,7 +53,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -70,7 +76,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -91,7 +99,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -112,7 +122,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -147,7 +159,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -168,7 +182,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -187,7 +203,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -206,7 +224,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -225,7 +245,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -248,7 +270,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/J25/TREASURES (2).json
+++ b/etc/J25/TREASURES (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -96,7 +102,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -131,7 +139,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -152,7 +162,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -171,7 +183,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -202,7 +216,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -221,7 +237,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/J25/VAMPIRES (1).json
+++ b/etc/J25/VAMPIRES (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -110,7 +112,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -167,7 +171,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/VAMPIRES (2).json
+++ b/etc/J25/VAMPIRES (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -110,7 +112,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -179,7 +183,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/VAMPIRES (3).json
+++ b/etc/J25/VAMPIRES (3).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -96,7 +98,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -167,7 +171,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/VAMPIRES (4).json
+++ b/etc/J25/VAMPIRES (4).json
@@ -5,7 +5,9 @@
     {
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
     }
   ],
   "cards": [
@@ -96,7 +98,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },
@@ -179,7 +183,9 @@
         {
           "name": "Blood",
           "type_line": "Token Artifact — Blood",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
         }
       ]
     },

--- a/etc/J25/WIZARDS (2).json
+++ b/etc/J25/WIZARDS (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -48,7 +52,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/J25/ZEALOTS (2).json
+++ b/etc/J25/ZEALOTS (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/J25/ZEALOTS (4).json
+++ b/etc/J25/ZEALOTS (4).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/JMP/ABOVE THE CLOUDS (2).json
+++ b/etc/JMP/ABOVE THE CLOUDS (2).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -130,7 +134,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/JMP/ANGELS (1).json
+++ b/etc/JMP/ANGELS (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Human",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
     }
   ],
   "cards": [
@@ -85,7 +91,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
         }
       ]
     },
@@ -162,7 +170,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },

--- a/etc/JMP/ANGELS (2).json
+++ b/etc/JMP/ANGELS (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     }
   ],
   "cards": [
@@ -154,7 +158,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },

--- a/etc/JMP/ARCHAEOLOGY (3).json
+++ b/etc/JMP/ARCHAEOLOGY (3).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "e3c8482e-ce21-43f8-ac07-c26c01941a4d"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "e3c8482e-ce21-43f8-ac07-c26c01941a4d"
         }
       ]
     },

--- a/etc/JMP/BASRI.json
+++ b/etc/JMP/BASRI.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Soldier",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -42,7 +48,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -95,7 +103,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/JMP/CATS (2).json
+++ b/etc/JMP/CATS (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "b1612d71-4e81-4ea7-95d9-05ed7a70e5f1"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "b1612d71-4e81-4ea7-95d9-05ed7a70e5f1"
         }
       ]
     },

--- a/etc/JMP/CHANDRA.json
+++ b/etc/JMP/CHANDRA.json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     }
   ],
   "cards": [
@@ -61,7 +63,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },

--- a/etc/JMP/DEVILISH (1).json
+++ b/etc/JMP/DEVILISH (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
         }
       ]
     },
@@ -167,7 +171,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
         }
       ]
     },

--- a/etc/JMP/DEVILISH (2).json
+++ b/etc/JMP/DEVILISH (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
         }
       ]
     },

--- a/etc/JMP/DEVILISH (3).json
+++ b/etc/JMP/DEVILISH (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
     }
   ],
   "cards": [
@@ -166,7 +168,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
         }
       ]
     },

--- a/etc/JMP/DINOSAURS (2).json
+++ b/etc/JMP/DINOSAURS (2).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "240300bd-5088-43c5-a873-290507515843"
     }
   ],
   "cards": [
@@ -62,7 +66,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "240300bd-5088-43c5-a873-290507515843"
         }
       ]
     },

--- a/etc/JMP/DINOSAURS (3).json
+++ b/etc/JMP/DINOSAURS (3).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "240300bd-5088-43c5-a873-290507515843"
     }
   ],
   "cards": [
@@ -62,7 +66,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Trample"
+          ],
+          "oracle_id": "240300bd-5088-43c5-a873-290507515843"
         }
       ]
     },

--- a/etc/JMP/DISCARDING (2).json
+++ b/etc/JMP/DISCARDING (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/DOCTOR (1).json
+++ b/etc/JMP/DOCTOR (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Griffin",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
     }
   ],
   "cards": [
@@ -85,7 +93,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },
@@ -184,7 +196,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
         }
       ]
     },

--- a/etc/JMP/DOCTOR (2).json
+++ b/etc/JMP/DOCTOR (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Griffin",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
     },
     {
       "name": "Soldier",
@@ -27,7 +35,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -94,7 +104,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },
@@ -145,7 +159,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -204,7 +220,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
         }
       ]
     },

--- a/etc/JMP/DOCTOR (3).json
+++ b/etc/JMP/DOCTOR (3).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
     }
   ],
   "cards": [
@@ -152,7 +156,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
         }
       ]
     },

--- a/etc/JMP/DOCTOR (4).json
+++ b/etc/JMP/DOCTOR (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
     }
   ],
   "cards": [
@@ -178,7 +182,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
         }
       ]
     },

--- a/etc/JMP/DOGS (1).json
+++ b/etc/JMP/DOGS (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -153,7 +157,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
         }
       ]
     },
@@ -176,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/DOGS (2).json
+++ b/etc/JMP/DOGS (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -153,7 +157,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
         }
       ]
     },
@@ -176,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/DRAGONS (1).json
+++ b/etc/JMP/DRAGONS (1).json
@@ -9,12 +9,16 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -47,7 +51,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -152,7 +158,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/DRAGONS (2).json
+++ b/etc/JMP/DRAGONS (2).json
@@ -9,7 +9,11 @@
         "R"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
     },
     {
       "name": "Goblin",
@@ -18,12 +22,16 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -48,7 +56,11 @@
             "R"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
         }
       ]
     },
@@ -69,7 +81,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -146,7 +160,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -183,7 +199,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/ELVES (1).json
+++ b/etc/JMP/ELVES (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -191,7 +195,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/JMP/ELVES (2).json
+++ b/etc/JMP/ELVES (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -191,7 +195,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/JMP/ENCHANTED (1).json
+++ b/etc/JMP/ENCHANTED (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -128,7 +132,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/JMP/ENCHANTED (2).json
+++ b/etc/JMP/ENCHANTED (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "6788478d-e157-4483-be09-9edb3f841431"
     },
     {
       "name": "Knight",
@@ -18,7 +20,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -43,7 +49,9 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "6788478d-e157-4483-be09-9edb3f841431"
         }
       ]
     },
@@ -160,7 +168,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/JMP/FEATHERED FRIENDS (1).json
+++ b/etc/JMP/FEATHERED FRIENDS (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/JMP/FEATHERED FRIENDS (2).json
+++ b/etc/JMP/FEATHERED FRIENDS (2).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
     },
     {
       "name": "Bird",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -99,7 +107,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },
@@ -176,7 +188,11 @@
             "W"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
         }
       ]
     },

--- a/etc/JMP/FEATHERED FRIENDS (3).json
+++ b/etc/JMP/FEATHERED FRIENDS (3).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/JMP/FEATHERED FRIENDS (4).json
+++ b/etc/JMP/FEATHERED FRIENDS (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     }
   ],
   "cards": [
@@ -76,7 +80,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },

--- a/etc/JMP/GARRUK.json
+++ b/etc/JMP/GARRUK.json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
     }
   ],
   "cards": [
@@ -33,7 +35,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         }
       ]
     },

--- a/etc/JMP/GOBLINS (1).json
+++ b/etc/JMP/GOBLINS (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -115,7 +119,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/GOBLINS (2).json
+++ b/etc/JMP/GOBLINS (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/GOBLINS (3).json
+++ b/etc/JMP/GOBLINS (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/GOBLINS (4).json
+++ b/etc/JMP/GOBLINS (4).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -87,7 +91,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },
@@ -164,7 +170,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/HEAVILY ARMORED (1).json
+++ b/etc/JMP/HEAVILY ARMORED (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -156,7 +158,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/HEAVILY ARMORED (2).json
+++ b/etc/JMP/HEAVILY ARMORED (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -156,7 +158,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/LANDS (1).json
+++ b/etc/JMP/LANDS (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
     }
   ],
   "cards": [
@@ -166,7 +168,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
         }
       ]
     },

--- a/etc/JMP/LANDS (2).json
+++ b/etc/JMP/LANDS (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/LEGION (1).json
+++ b/etc/JMP/LEGION (1).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
     },
     {
       "name": "Knight",
@@ -18,7 +22,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Soldier",
@@ -27,7 +35,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -80,7 +90,11 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
         }
       ]
     },
@@ -105,7 +119,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },
@@ -204,7 +222,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/LEGION (2).json
+++ b/etc/JMP/LEGION (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
     },
     {
       "name": "Knight",
@@ -18,7 +20,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Soldier",
@@ -27,7 +33,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -80,7 +88,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },
@@ -145,7 +157,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
         }
       ]
     },
@@ -192,7 +206,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/LEGION (3).json
+++ b/etc/JMP/LEGION (3).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
     },
     {
       "name": "Knight",
@@ -18,7 +20,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Soldier",
@@ -27,7 +33,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -66,7 +74,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },
@@ -143,7 +155,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
         }
       ]
     },
@@ -190,7 +204,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/LEGION (4).json
+++ b/etc/JMP/LEGION (4).json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     },
     {
       "name": "Soldier",
@@ -18,7 +22,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -43,7 +49,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -110,7 +118,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },
@@ -197,7 +209,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },

--- a/etc/JMP/LILIANA.json
+++ b/etc/JMP/LILIANA.json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -131,7 +133,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/MINIONS (1).json
+++ b/etc/JMP/MINIONS (1).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/MINIONS (2).json
+++ b/etc/JMP/MINIONS (2).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -90,7 +92,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/MINIONS (3).json
+++ b/etc/JMP/MINIONS (3).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -115,7 +119,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/MINIONS (4).json
+++ b/etc/JMP/MINIONS (4).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -73,7 +77,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },
@@ -140,7 +146,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/MINOTAURS (1).json
+++ b/etc/JMP/MINOTAURS (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
         }
       ]
     },
@@ -141,7 +145,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
         }
       ]
     },

--- a/etc/JMP/MINOTAURS (2).json
+++ b/etc/JMP/MINOTAURS (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
         }
       ]
     },
@@ -141,7 +145,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
         }
       ]
     },

--- a/etc/JMP/PHYREXIAN.json
+++ b/etc/JMP/PHYREXIAN.json
@@ -7,7 +7,9 @@
       "type_line": "Token Artifact Creature — Phyrexian Myr",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2"
     }
   ],
   "cards": [
@@ -70,7 +72,9 @@
           "type_line": "Token Artifact Creature — Phyrexian Myr",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2"
         }
       ]
     },
@@ -181,7 +185,9 @@
           "type_line": "Token Artifact Creature — Phyrexian Myr",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2"
         }
       ]
     },

--- a/etc/JMP/PIRATES (1).json
+++ b/etc/JMP/PIRATES (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -103,7 +107,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -124,7 +130,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/JMP/PIRATES (2).json
+++ b/etc/JMP/PIRATES (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -89,7 +93,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -124,7 +130,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/JMP/PLUS ONE (1).json
+++ b/etc/JMP/PLUS ONE (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
     }
   ],
   "cards": [
@@ -166,7 +168,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         }
       ]
     },

--- a/etc/JMP/PREDATORY (1).json
+++ b/etc/JMP/PREDATORY (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
     },
     {
       "name": "Saproling",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -85,7 +89,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
         }
       ]
     },
@@ -186,7 +192,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/PREDATORY (2).json
+++ b/etc/JMP/PREDATORY (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
     },
     {
       "name": "Saproling",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -83,7 +87,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
         }
       ]
     },
@@ -184,7 +190,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/PREDATORY (3).json
+++ b/etc/JMP/PREDATORY (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
     },
     {
       "name": "Boar",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
     },
     {
       "name": "Saproling",
@@ -27,7 +31,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -52,7 +58,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
         }
       ]
     },
@@ -91,7 +99,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
         }
       ]
     },
@@ -204,7 +214,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/PREDATORY (4).json
+++ b/etc/JMP/PREDATORY (4).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [],
+      "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
     },
     {
       "name": "Saproling",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -71,7 +75,9 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [],
+          "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
         }
       ]
     },
@@ -198,7 +204,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/RAINBOW.json
+++ b/etc/JMP/RAINBOW.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
     }
   ],
   "cards": [
@@ -113,7 +115,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
         }
       ]
     },
@@ -262,7 +266,12 @@
     {
       "quantity": 1,
       "name": "Rainbow Terramorphic Expanse",
-      "type": "Unknown"
+      "type": "Lands",
+      "type_line": "Land",
+      "mana_cost": "",
+      "cmc": 0.0,
+      "colors": [],
+      "rarity": "common"
     }
   ]
 }

--- a/etc/JMP/REANIMATED (1).json
+++ b/etc/JMP/REANIMATED (1).json
@@ -9,7 +9,11 @@
         "B"
       ],
       "power": "5",
-      "toughness": "5"
+      "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
     }
   ],
   "cards": [
@@ -104,7 +108,11 @@
             "B"
           ],
           "power": "5",
-          "toughness": "5"
+          "toughness": "5",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
         }
       ]
     },

--- a/etc/JMP/REANIMATED (3).json
+++ b/etc/JMP/REANIMATED (3).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -178,7 +180,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/SPELLCASTING (2).json
+++ b/etc/JMP/SPELLCASTING (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
         }
       ]
     },

--- a/etc/JMP/SPELLCASTING (3).json
+++ b/etc/JMP/SPELLCASTING (3).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
     }
   ],
   "cards": [
@@ -144,7 +146,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
         }
       ]
     },

--- a/etc/JMP/SPELLINGCASTING (1).json
+++ b/etc/JMP/SPELLINGCASTING (1).json
@@ -9,7 +9,11 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692"
     }
   ],
   "cards": [
@@ -140,7 +144,11 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Prowess"
+          ],
+          "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692"
         }
       ]
     },

--- a/etc/JMP/SPOOKY (3).json
+++ b/etc/JMP/SPOOKY (3).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
     },
     {
       "name": "Zombie",
@@ -18,7 +20,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -43,7 +47,9 @@
             "B"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
         }
       ]
     },
@@ -124,7 +130,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/SPOOKY (4).json
+++ b/etc/JMP/SPOOKY (4).json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
     }
   ],
   "cards": [
@@ -118,7 +120,9 @@
             "B"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
         }
       ]
     },

--- a/etc/JMP/TEFERI.json
+++ b/etc/JMP/TEFERI.json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -115,7 +119,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/JMP/TREE-HUGGING (1).json
+++ b/etc/JMP/TREE-HUGGING (1).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/JMP/TREE-HUGGING (2).json
+++ b/etc/JMP/TREE-HUGGING (2).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },

--- a/etc/JMP/TREE-HUGGING (3).json
+++ b/etc/JMP/TREE-HUGGING (3).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "2069c2cb-3cb7-4f3b-be72-ae783de82c42"
     },
     {
       "name": "Elf Warrior",
@@ -18,7 +20,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
     }
   ],
   "cards": [
@@ -57,7 +61,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
         }
       ]
     },
@@ -82,7 +88,9 @@
             "G"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "2069c2cb-3cb7-4f3b-be72-ae783de82c42"
         }
       ]
     },

--- a/etc/JMP/TREE-HUGGING (4).json
+++ b/etc/JMP/TREE-HUGGING (4).json
@@ -9,7 +9,9 @@
         "G"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
     }
   ],
   "cards": [
@@ -178,7 +180,9 @@
             "G"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
         }
       ]
     },

--- a/etc/JMP/UNDER THE SEA (1).json
+++ b/etc/JMP/UNDER THE SEA (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18"
     }
   ],
   "cards": [
@@ -90,7 +92,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18"
         }
       ]
     },

--- a/etc/JMP/UNDER THE SEA (2).json
+++ b/etc/JMP/UNDER THE SEA (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18"
         }
       ]
     },

--- a/etc/JMP/UNICORNS.json
+++ b/etc/JMP/UNICORNS.json
@@ -9,7 +9,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
     }
   ],
   "cards": [
@@ -104,7 +108,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
         }
       ]
     },

--- a/etc/JMP/WITCHCRAFT (1).json
+++ b/etc/JMP/WITCHCRAFT (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -68,7 +70,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -129,7 +133,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/JMP/WITCHCRAFT (2).json
+++ b/etc/JMP/WITCHCRAFT (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -141,7 +145,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/JMP/WIZARDS (1).json
+++ b/etc/JMP/WIZARDS (1).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },
@@ -113,7 +121,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/JMP/WIZARDS (2).json
+++ b/etc/JMP/WIZARDS (2).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -116,7 +120,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/JMP/WIZARDS (3).json
+++ b/etc/JMP/WIZARDS (3).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -34,7 +38,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },
@@ -113,7 +121,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/JMP/WIZARDS (4).json
+++ b/etc/JMP/WIZARDS (4).json
@@ -9,7 +9,11 @@
         "U"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
     }
   ],
   "cards": [
@@ -116,7 +120,11 @@
             "U"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
         }
       ]
     },

--- a/etc/LTR/COURAGEOUS 1.json
+++ b/etc/LTR/COURAGEOUS 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -82,7 +84,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -117,7 +121,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/COURAGEOUS 2.json
+++ b/etc/LTR/COURAGEOUS 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -82,7 +84,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -103,7 +107,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -124,7 +130,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/CUNNING 2.json
+++ b/etc/LTR/CUNNING 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -82,7 +84,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },

--- a/etc/LTR/ELVEN 1.json
+++ b/etc/LTR/ELVEN 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -134,7 +136,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/ELVEN 2.json
+++ b/etc/LTR/ELVEN 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -122,7 +124,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -153,7 +157,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/JOURNEY 1.json
+++ b/etc/LTR/JOURNEY 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -82,7 +88,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -155,7 +163,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/JOURNEY 2.json
+++ b/etc/LTR/JOURNEY 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -61,7 +65,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -82,7 +88,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -103,7 +111,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -150,7 +160,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -169,7 +181,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/MARAUDERS 1.json
+++ b/etc/LTR/MARAUDERS 1.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     },
     {
       "name": "Orc Army",
@@ -18,12 +20,16 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -76,7 +82,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -127,7 +135,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -146,7 +156,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         },
         {
           "name": "Orc Army",
@@ -155,7 +167,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -178,7 +192,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -213,7 +229,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/LTR/MARAUDERS 2.json
+++ b/etc/LTR/MARAUDERS 2.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     },
     {
       "name": "Orc Army",
@@ -18,12 +20,16 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -76,7 +82,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -127,7 +135,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -146,7 +156,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         },
         {
           "name": "Orc Army",
@@ -155,7 +167,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -178,7 +192,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -201,7 +217,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/LTR/MORDOR 1.json
+++ b/etc/LTR/MORDOR 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Orc Army",
@@ -14,7 +16,9 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     }
   ],
   "cards": [
@@ -95,7 +99,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -116,7 +122,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -139,7 +147,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -194,7 +204,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/MORDOR 2.json
+++ b/etc/LTR/MORDOR 2.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Orc Army",
@@ -14,7 +16,9 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     }
   ],
   "cards": [
@@ -67,7 +71,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -92,7 +98,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -117,7 +125,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -138,7 +148,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -161,7 +173,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -220,7 +234,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },

--- a/etc/LTR/MORTALS 1.json
+++ b/etc/LTR/MORTALS 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Human Soldier",
@@ -14,7 +16,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -63,7 +67,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -130,7 +136,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -161,7 +169,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/LTR/MORTALS 2.json
+++ b/etc/LTR/MORTALS 2.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/LTR/ORCISH 1.json
+++ b/etc/LTR/ORCISH 1.json
@@ -9,12 +9,16 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -39,7 +43,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -64,7 +70,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -89,7 +97,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -124,7 +134,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -149,7 +161,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -172,7 +186,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -207,7 +223,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },

--- a/etc/LTR/ORCISH 2.json
+++ b/etc/LTR/ORCISH 2.json
@@ -7,12 +7,18 @@
       "type_line": "Token Artifact Creature — Construct",
       "colors": [],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Orc Army",
@@ -21,12 +27,16 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -51,7 +61,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -76,7 +88,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -101,7 +115,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -124,7 +140,11 @@
           "type_line": "Token Artifact Creature — Construct",
           "colors": [],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
         }
       ]
     },
@@ -145,7 +165,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -170,7 +192,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -191,7 +215,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -214,7 +240,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -261,7 +289,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },

--- a/etc/LTR/RIDERS 1.json
+++ b/etc/LTR/RIDERS 1.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -101,7 +105,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -124,7 +130,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -147,7 +155,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/LTR/RIDERS 2.json
+++ b/etc/LTR/RIDERS 2.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     },
     {
       "name": "Orc Army",
@@ -18,7 +20,9 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     }
   ],
   "cards": [
@@ -43,7 +47,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -124,7 +130,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -147,7 +155,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },
@@ -206,7 +216,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },

--- a/etc/LTR/TRICKSY 2.json
+++ b/etc/LTR/TRICKSY 2.json
@@ -9,7 +9,9 @@
         "B"
       ],
       "power": "0",
-      "toughness": "0"
+      "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
     }
   ],
   "cards": [
@@ -104,7 +106,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },
@@ -177,7 +181,9 @@
             "B"
           ],
           "power": "0",
-          "toughness": "0"
+          "toughness": "0",
+          "keywords": [],
+          "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
         }
       ]
     },

--- a/etc/MOM/BROOD 1.json
+++ b/etc/MOM/BROOD 1.json
@@ -5,7 +5,11 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     }
   ],
   "cards": [
@@ -26,7 +30,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -47,7 +55,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -96,7 +108,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -145,7 +161,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -164,7 +184,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/BROOD 2.json
+++ b/etc/MOM/BROOD 2.json
@@ -5,7 +5,11 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     }
   ],
   "cards": [
@@ -26,7 +30,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -75,7 +83,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -110,7 +122,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -145,7 +161,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/BUFF 1.json
+++ b/etc/MOM/BUFF 1.json
@@ -5,7 +5,11 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     }
   ],
   "cards": [
@@ -68,7 +72,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/BUFF 2.json
+++ b/etc/MOM/BUFF 2.json
@@ -5,7 +5,11 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     }
   ],
   "cards": [
@@ -68,7 +72,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -167,7 +175,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/EXPENDABLE 1.json
+++ b/etc/MOM/EXPENDABLE 1.json
@@ -5,12 +5,18 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +37,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -158,7 +168,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -177,7 +189,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/EXPENDABLE 2.json
+++ b/etc/MOM/EXPENDABLE 2.json
@@ -5,12 +5,18 @@
     {
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-      "colors": []
+      "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -31,7 +37,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -108,7 +118,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },
@@ -153,7 +167,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -184,7 +200,11 @@
         {
           "name": "Incubator // Phyrexian",
           "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-          "colors": []
+          "colors": [],
+          "keywords": [
+            "Transform"
+          ],
+          "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
         }
       ]
     },

--- a/etc/MOM/OVERACHIEVER 1.json
+++ b/etc/MOM/OVERACHIEVER 1.json
@@ -10,7 +10,9 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
     }
   ],
   "cards": [
@@ -64,7 +66,9 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
         }
       ]
     },

--- a/etc/MOM/OVERACHIEVER 2.json
+++ b/etc/MOM/OVERACHIEVER 2.json
@@ -10,7 +10,11 @@
         "W"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "8d7d636d-4ae7-4411-8f45-fc57fead851e"
     }
   ],
   "cards": [
@@ -120,7 +124,11 @@
             "W"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Vigilance"
+          ],
+          "oracle_id": "8d7d636d-4ae7-4411-8f45-fc57fead851e"
         }
       ]
     },

--- a/etc/MOM/REINFORCEMENT 1.json
+++ b/etc/MOM/REINFORCEMENT 1.json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Elemental",
@@ -15,12 +17,16 @@
         "U"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -97,7 +103,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -132,7 +140,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -156,7 +166,9 @@
             "U"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
         }
       ]
     },

--- a/etc/MOM/REINFORCEMENT 2.json
+++ b/etc/MOM/REINFORCEMENT 2.json
@@ -5,12 +5,16 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
     }
   ],
   "cards": [
@@ -101,7 +105,9 @@
         {
           "name": "Treasure",
           "type_line": "Token Artifact — Treasure",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
         }
       ]
     },
@@ -136,7 +142,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/ONE/CORRUPTION (1).json
+++ b/etc/ONE/CORRUPTION (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },

--- a/etc/ONE/CORRUPTION (2).json
+++ b/etc/ONE/CORRUPTION (2).json
@@ -5,14 +5,20 @@
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Phyrexian Mite",
       "type_line": "Token Artifact Creature — Phyrexian Mite",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
     }
   ],
   "cards": [
@@ -33,7 +39,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -70,7 +78,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },

--- a/etc/ONE/MITE-Y (1).json
+++ b/etc/ONE/MITE-Y (1).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Phyrexian Mite",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
     }
   ],
   "cards": [
@@ -30,7 +34,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },
@@ -95,7 +103,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },
@@ -144,7 +156,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },
@@ -177,7 +193,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },

--- a/etc/ONE/MITE-Y (2).json
+++ b/etc/ONE/MITE-Y (2).json
@@ -7,7 +7,11 @@
       "type_line": "Token Artifact Creature — Phyrexian Mite",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
     }
   ],
   "cards": [
@@ -30,7 +34,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },
@@ -67,7 +75,11 @@
           "type_line": "Token Artifact Creature — Phyrexian Mite",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
         }
       ]
     },

--- a/etc/ONE/REBELLIOUS (1).json
+++ b/etc/ONE/REBELLIOUS (1).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "b43340e3-bb76-4501-8db2-040b7cae33b7"
     },
     {
       "name": "Rebel",
@@ -18,7 +20,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     }
   ],
   "cards": [
@@ -71,7 +75,9 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "b43340e3-bb76-4501-8db2-040b7cae33b7"
         }
       ]
     },
@@ -158,7 +164,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -181,7 +189,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -204,7 +214,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },

--- a/etc/ONE/REBELLIOUS (2).json
+++ b/etc/ONE/REBELLIOUS (2).json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
     }
   ],
   "cards": [
@@ -124,7 +126,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -147,7 +151,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },
@@ -170,7 +176,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
         }
       ]
     },

--- a/etc/ONE/TOXIC (1).json
+++ b/etc/ONE/TOXIC (1).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
     }
   ],
   "cards": [
@@ -164,7 +168,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
         }
       ]
     },

--- a/etc/ONE/TOXIC (2).json
+++ b/etc/ONE/TOXIC (2).json
@@ -9,7 +9,11 @@
         "G"
       ],
       "power": "3",
-      "toughness": "3"
+      "toughness": "3",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
     }
   ],
   "cards": [
@@ -128,7 +132,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
         }
       ]
     },
@@ -163,7 +171,11 @@
             "G"
           ],
           "power": "3",
-          "toughness": "3"
+          "toughness": "3",
+          "keywords": [
+            "Toxic"
+          ],
+          "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
         }
       ]
     },

--- a/etc/TLA/AANG.json
+++ b/etc/TLA/AANG.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -115,7 +119,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -140,7 +146,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -213,7 +221,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/ADAPTIVE.json
+++ b/etc/TLA/ADAPTIVE.json
@@ -9,14 +9,18 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Spirit",
       "type_line": "Token Creature — Spirit",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
     }
   ],
   "cards": [
@@ -147,7 +151,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },
@@ -192,7 +198,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/ADEPT (1).json
+++ b/etc/TLA/ADEPT (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -41,7 +43,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/ADEPT (2).json
+++ b/etc/TLA/ADEPT (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -159,7 +161,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/AIRBENDING.json
+++ b/etc/TLA/AIRBENDING.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -48,7 +50,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -191,7 +195,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/ALLIANCE (1).json
+++ b/etc/TLA/ALLIANCE (1).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -110,7 +114,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -136,7 +142,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -170,7 +178,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -215,7 +225,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/ALLIANCE (2).json
+++ b/etc/TLA/ALLIANCE (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -105,7 +107,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -131,7 +135,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/AT THE ZOO.json
+++ b/etc/TLA/AT THE ZOO.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -82,7 +84,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/TLA/AZULA.json
+++ b/etc/TLA/AZULA.json
@@ -7,17 +7,25 @@
       "type_line": "Token Artifact Creature — Construct",
       "colors": [],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -82,7 +90,11 @@
           "type_line": "Token Artifact Creature — Construct",
           "colors": [],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
         }
       ]
     },
@@ -131,7 +143,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -186,7 +200,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/BAD ADVICE.json
+++ b/etc/TLA/BAD ADVICE.json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     }
   ],
   "cards": [
@@ -73,7 +77,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -186,7 +192,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/BOUNTY HUNTER (1).json
+++ b/etc/TLA/BOUNTY HUNTER (1).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Human Soldier",
@@ -23,7 +27,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -63,7 +69,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -84,7 +92,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -133,7 +143,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -168,7 +180,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -199,7 +213,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -234,7 +250,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/TLA/BOUNTY HUNTER (2).json
+++ b/etc/TLA/BOUNTY HUNTER (2).json
@@ -9,19 +9,27 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Ballistic Boulder",
       "type_line": "Token Artifact Creature — Construct",
       "colors": [],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Human Soldier",
@@ -30,7 +38,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
     }
   ],
   "cards": [
@@ -51,7 +61,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -77,7 +89,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -98,7 +112,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -135,7 +151,11 @@
           "type_line": "Token Artifact Creature — Construct",
           "colors": [],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
         }
       ]
     },
@@ -156,7 +176,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -192,7 +214,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -223,7 +247,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -242,7 +268,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -265,7 +293,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
         }
       ]
     },

--- a/etc/TLA/BUMI.json
+++ b/etc/TLA/BUMI.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -109,7 +111,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -164,7 +168,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/TLA/CABBAGES.json
+++ b/etc/TLA/CABBAGES.json
@@ -5,7 +5,9 @@
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -47,7 +51,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -68,7 +74,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -103,7 +111,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -150,7 +160,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -169,7 +181,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -188,7 +202,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -219,7 +235,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/TLA/EARTH KINGDOM (1).json
+++ b/etc/TLA/EARTH KINGDOM (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -63,7 +65,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -129,7 +133,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -175,7 +181,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/EARTH KINGDOM (2).json
+++ b/etc/TLA/EARTH KINGDOM (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -91,7 +93,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/EARTH RUMBLE (1).json
+++ b/etc/TLA/EARTH RUMBLE (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -167,7 +169,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/EARTH RUMBLE (2).json
+++ b/etc/TLA/EARTH RUMBLE (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Bear",
@@ -18,12 +20,16 @@
         "G"
       ],
       "power": "4",
-      "toughness": "4"
+      "toughness": "4",
+      "keywords": [],
+      "oracle_id": "af4bd34a-0a0b-4c53-8f13-579c45ab471a"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -91,7 +97,9 @@
             "G"
           ],
           "power": "4",
-          "toughness": "4"
+          "toughness": "4",
+          "keywords": [],
+          "oracle_id": "af4bd34a-0a0b-4c53-8f13-579c45ab471a"
         }
       ]
     },
@@ -141,7 +149,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -199,7 +209,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/FIRE NATION.json
+++ b/etc/TLA/FIRE NATION.json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Soldier",
@@ -14,7 +16,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -120,7 +126,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },
@@ -151,7 +161,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/FIREBENDING (1).json
+++ b/etc/TLA/FIREBENDING (1).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Soldier",
@@ -23,7 +27,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -76,7 +84,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -173,7 +183,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -208,7 +220,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },

--- a/etc/TLA/FIREBENDING (2).json
+++ b/etc/TLA/FIREBENDING (2).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Soldier",
@@ -23,7 +27,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -90,7 +98,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -167,7 +177,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },
@@ -198,7 +212,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/FREEDOM FIGHTERS.json
+++ b/etc/TLA/FREEDOM FIGHTERS.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -170,7 +172,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -193,7 +197,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/GLIDING (1).json
+++ b/etc/TLA/GLIDING (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -180,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/GLIDING (2).json
+++ b/etc/TLA/GLIDING (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -180,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/HEI BAI (1).json
+++ b/etc/TLA/HEI BAI (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -34,7 +36,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -60,7 +64,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -114,7 +120,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -216,7 +224,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/HEI BAI (2).json
+++ b/etc/TLA/HEI BAI (2).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -68,7 +72,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -108,7 +114,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -182,7 +190,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -217,7 +227,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/HUNTING (1).json
+++ b/etc/TLA/HUNTING (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -54,7 +56,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -75,7 +79,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -97,7 +103,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/HUNTING (2).json
+++ b/etc/TLA/HUNTING (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -54,7 +56,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -75,7 +79,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -97,7 +103,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/INSURGENT (1).json
+++ b/etc/TLA/INSURGENT (1).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -76,7 +78,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -115,7 +119,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/INSURGENT (2).json
+++ b/etc/TLA/INSURGENT (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -105,7 +107,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -181,7 +185,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/KYOSHI.json
+++ b/etc/TLA/KYOSHI.json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -49,7 +53,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -89,7 +95,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -187,7 +195,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/LEARNING (1).json
+++ b/etc/TLA/LEARNING (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -156,7 +158,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/LEARNING (2).json
+++ b/etc/TLA/LEARNING (2).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -116,7 +120,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -147,7 +153,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -176,7 +184,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/LESSONS (2).json
+++ b/etc/TLA/LESSONS (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -146,7 +148,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/LIBRARIAN.json
+++ b/etc/TLA/LIBRARIAN.json
@@ -5,14 +5,18 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Spirit",
       "type_line": "Token Creature — Spirit",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
     }
   ],
   "cards": [
@@ -60,7 +64,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -97,7 +103,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },
@@ -132,7 +140,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },
@@ -197,7 +207,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/MUSICIANS.json
+++ b/etc/TLA/MUSICIANS.json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -156,7 +160,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -179,7 +185,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -202,7 +210,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/NIGHTMARES.json
+++ b/etc/TLA/NIGHTMARES.json
@@ -9,22 +9,30 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -64,7 +72,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -85,7 +95,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -120,7 +132,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -156,7 +170,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/TLA/OZAI.json
+++ b/etc/TLA/OZAI.json
@@ -7,17 +7,25 @@
       "type_line": "Token Artifact Creature — Construct",
       "colors": [],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -38,7 +46,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -89,7 +99,11 @@
           "type_line": "Token Artifact Creature — Construct",
           "colors": [],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
         }
       ]
     },
@@ -153,7 +167,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },

--- a/etc/TLA/POWERFUL (1).json
+++ b/etc/TLA/POWERFUL (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -84,7 +86,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/POWERFUL (2).json
+++ b/etc/TLA/POWERFUL (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -83,7 +85,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/REBELLING (1).json
+++ b/etc/TLA/REBELLING (1).json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Soldier",
@@ -23,7 +27,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -76,7 +84,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -181,7 +191,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },
@@ -200,7 +214,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/REBELLING (2).json
+++ b/etc/TLA/REBELLING (2).json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -192,7 +196,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/REINFORCED (1).json
+++ b/etc/TLA/REINFORCED (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -26,7 +28,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/RELENTLESS (1).json
+++ b/etc/TLA/RELENTLESS (1).json
@@ -5,12 +5,16 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Soldier",
@@ -19,7 +23,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -110,7 +118,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -145,7 +155,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -164,7 +176,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -211,7 +225,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },

--- a/etc/TLA/RELENTLESS (2).json
+++ b/etc/TLA/RELENTLESS (2).json
@@ -5,17 +5,23 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Copy",
       "type_line": "Token",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     },
     {
       "name": "Soldier",
@@ -24,7 +30,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -45,7 +55,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -80,7 +92,9 @@
         {
           "name": "Copy",
           "type_line": "Token",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
         }
       ]
     },
@@ -115,7 +129,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -165,7 +181,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -224,7 +242,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },

--- a/etc/TLA/ROKU.json
+++ b/etc/TLA/ROKU.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Monk",
@@ -18,7 +20,11 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d"
     }
   ],
   "cards": [
@@ -85,7 +91,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -186,7 +194,11 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Prowess"
+          ],
+          "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d"
         }
       ]
     },

--- a/etc/TLA/SHRINES.json
+++ b/etc/TLA/SHRINES.json
@@ -9,14 +9,20 @@
         "R"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d"
     },
     {
       "name": "Spirit",
       "type_line": "Token Creature — Spirit",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
     }
   ],
   "cards": [
@@ -67,7 +73,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },
@@ -187,7 +195,11 @@
             "R"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Prowess"
+          ],
+          "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d"
         }
       ]
     },

--- a/etc/TLA/SIEGE ENGINES.json
+++ b/etc/TLA/SIEGE ENGINES.json
@@ -9,24 +9,34 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Ballistic Boulder",
       "type_line": "Token Artifact Creature — Construct",
       "colors": [],
       "power": "2",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Food",
       "type_line": "Token Artifact — Food",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
     }
   ],
   "cards": [
@@ -47,7 +57,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -87,7 +99,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -124,7 +138,11 @@
           "type_line": "Token Artifact Creature — Construct",
           "colors": [],
           "power": "2",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [
+            "Flying"
+          ],
+          "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
         }
       ]
     },
@@ -159,7 +177,9 @@
         {
           "name": "Food",
           "type_line": "Token Artifact — Food",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
         }
       ]
     },
@@ -200,7 +220,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/SOARING (1).json
+++ b/etc/TLA/SOARING (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -62,7 +66,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -98,7 +104,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/SOARING (2).json
+++ b/etc/TLA/SOARING (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -55,7 +57,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/SPIRIT.json
+++ b/etc/TLA/SPIRIT.json
@@ -5,14 +5,18 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     },
     {
       "name": "Spirit",
       "type_line": "Token Creature — Spirit",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
     }
   ],
   "cards": [
@@ -61,7 +65,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -98,7 +104,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },
@@ -147,7 +155,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },

--- a/etc/TLA/SWORDMASTER.json
+++ b/etc/TLA/SWORDMASTER.json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -117,7 +121,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -150,7 +156,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/WARRIORS.json
+++ b/etc/TLA/WARRIORS.json
@@ -9,12 +9,16 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -53,7 +57,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -121,7 +127,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -154,7 +162,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -187,7 +197,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -210,7 +222,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLA/WISE (1).json
+++ b/etc/TLA/WISE (1).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -40,7 +42,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -104,7 +108,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/WISE (2).json
+++ b/etc/TLA/WISE (2).json
@@ -5,7 +5,9 @@
     {
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
-      "colors": []
+      "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
     }
   ],
   "cards": [
@@ -54,7 +56,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },
@@ -105,7 +109,9 @@
         {
           "name": "Clue",
           "type_line": "Token Artifact — Clue",
-          "colors": []
+          "colors": [],
+          "keywords": [],
+          "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
         }
       ]
     },

--- a/etc/TLA/ZUKO.json
+++ b/etc/TLA/ZUKO.json
@@ -9,7 +9,11 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
     }
   ],
   "cards": [
@@ -102,7 +106,11 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [
+            "Firebending"
+          ],
+          "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
         }
       ]
     },

--- a/etc/TLB/AANG TUTORIAL.json
+++ b/etc/TLB/AANG TUTORIAL.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -182,7 +184,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLB/ALLIES.json
+++ b/etc/TLB/ALLIES.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -105,7 +107,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -178,7 +182,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -201,7 +207,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLB/ATTACKING.json
+++ b/etc/TLB/ATTACKING.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -77,7 +79,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLB/BIG CREATURES.json
+++ b/etc/TLB/BIG CREATURES.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     }
   ],
   "cards": [
@@ -144,7 +146,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },

--- a/etc/TLB/FIREBENDING.json
+++ b/etc/TLB/FIREBENDING.json
@@ -9,7 +9,9 @@
         "W"
       ],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
     },
     {
       "name": "Soldier",
@@ -18,7 +20,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
     }
   ],
   "cards": [
@@ -100,7 +104,9 @@
             "W"
           ],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
         }
       ]
     },
@@ -139,7 +145,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
         }
       ]
     },

--- a/etc/TLB/SPELLS.json
+++ b/etc/TLB/SPELLS.json
@@ -7,7 +7,9 @@
       "type_line": "Token Creature — Spirit",
       "colors": [],
       "power": "1",
-      "toughness": "1"
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
     }
   ],
   "cards": [
@@ -126,7 +128,9 @@
           "type_line": "Token Creature — Spirit",
           "colors": [],
           "power": "1",
-          "toughness": "1"
+          "toughness": "1",
+          "keywords": [],
+          "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
         }
       ]
     },

--- a/etc/TLB/ZUKO TUTORIAL.json
+++ b/etc/TLB/ZUKO TUTORIAL.json
@@ -9,7 +9,9 @@
         "R"
       ],
       "power": "2",
-      "toughness": "2"
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
     }
   ],
   "cards": [
@@ -62,7 +64,9 @@
             "R"
           ],
           "power": "2",
-          "toughness": "2"
+          "toughness": "2",
+          "keywords": [],
+          "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
         }
       ]
     },

--- a/etc/jumpstart-token-index.json
+++ b/etc/jumpstart-token-index.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "generated": "2026-04-26T21:13:00.047620+00:00",
-    "total_tokens": 86,
-    "total_source_refs": 922,
+    "generated": "2026-04-26T21:17:02.289146+00:00",
+    "total_tokens": 101,
+    "total_source_refs": 921,
     "decks_scanned": 529,
     "sets": [
       "JMP",
@@ -28,6 +28,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "9fcff433-c6f7-44c6-8279-04625703cb3e",
       "sources": [
         {
           "set": "J22",
@@ -45,6 +47,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f",
       "sources": [
         {
           "set": "TLA",
@@ -410,6 +414,10 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f",
       "sources": [
         {
           "set": "JMP",
@@ -450,12 +458,6 @@
         {
           "set": "J22",
           "set_name": "JumpStart 2022",
-          "deck": "HOLY (3)",
-          "card": "Valkyrie Harbinger"
-        },
-        {
-          "set": "J22",
-          "set_name": "JumpStart 2022",
           "deck": "LAW (2)",
           "card": "Decree of Justice"
         },
@@ -464,6 +466,34 @@
           "set_name": "JumpStart Foundations",
           "deck": "HEALERS (1)",
           "card": "Speaker of the Heavens"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Urbis Protector"
+        }
+      ]
+    },
+    {
+      "name": "Angel",
+      "type_line": "Token Creature — Angel",
+      "colors": [
+        "W"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (3)",
+          "card": "Valkyrie Harbinger"
         },
         {
           "set": "J25",
@@ -476,12 +506,6 @@
           "set_name": "Ravnica: Clue Edition",
           "deck": "BOROS LEGION 1",
           "card": "Finale of Glory"
-        },
-        {
-          "set": "CLU",
-          "set_name": "Ravnica: Clue Edition",
-          "deck": "SELESNYA CONCLAVE 1",
-          "card": "Urbis Protector"
         }
       ]
     },
@@ -493,6 +517,11 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [
+        "Flying",
+        "Vigilance"
+      ],
+      "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c",
       "sources": [
         {
           "set": "J25",
@@ -514,6 +543,8 @@
       "colors": [],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "02e1a471-36b2-4d28-a323-f4ec3d095cb9",
       "sources": [
         {
           "set": "J22",
@@ -529,6 +560,10 @@
       "colors": [],
       "power": "2",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216",
       "sources": [
         {
           "set": "TLA",
@@ -570,6 +605,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794",
       "sources": [
         {
           "set": "CLU",
@@ -593,6 +632,8 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [],
+      "oracle_id": "af4bd34a-0a0b-4c53-8f13-579c45ab471a",
       "sources": [
         {
           "set": "TLA",
@@ -610,6 +651,8 @@
       ],
       "power": "3",
       "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920",
       "sources": [
         {
           "set": "JMP",
@@ -651,18 +694,14 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [],
+      "oracle_id": "695b14a0-920a-47bd-bd4a-7989862cdd0a",
       "sources": [
         {
           "set": "J22",
           "set_name": "JumpStart 2022",
           "deck": "LANDFALL (1)",
           "card": "Rampaging Baloths"
-        },
-        {
-          "set": "J25",
-          "set_name": "JumpStart Foundations",
-          "deck": "EXPLORERS (3)",
-          "card": "Somberwald Beastmaster"
         }
       ]
     },
@@ -674,6 +713,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297",
       "sources": [
         {
           "set": "JMP",
@@ -745,6 +788,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "6c29dcc1-d7b6-4ef6-b663-0cc0e4be0529",
       "sources": [
         {
           "set": "J25",
@@ -758,6 +805,8 @@
       "name": "Blood",
       "type_line": "Token Artifact — Blood",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779",
       "sources": [
         {
           "set": "J25",
@@ -925,6 +974,8 @@
       ],
       "power": "3",
       "toughness": "3",
+      "keywords": [],
+      "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a",
       "sources": [
         {
           "set": "JMP",
@@ -960,6 +1011,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Food"
+      ],
+      "oracle_id": "a6f7f5c7-8832-40f8-803e-f181571422f8",
       "sources": [
         {
           "set": "J22",
@@ -977,6 +1032,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "11734409-b03b-4905-af83-261f29a96bc2",
       "sources": [
         {
           "set": "CLU",
@@ -994,6 +1051,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "5e34ad53-c154-4302-b25a-fe4bb1555a5f",
       "sources": [
         {
           "set": "J22",
@@ -1011,6 +1072,8 @@
       ],
       "power": "2",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "b1612d71-4e81-4ea7-95d9-05ed7a70e5f1",
       "sources": [
         {
           "set": "JMP",
@@ -1028,13 +1091,28 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "6788478d-e157-4483-be09-9edb3f841431",
       "sources": [
         {
           "set": "JMP",
           "set_name": "JumpStart 2020",
           "deck": "ENCHANTED (2)",
           "card": "Ajani's Chosen"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Cat",
+      "type_line": "Token Creature — Cat",
+      "colors": [
+        "G"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "2069c2cb-3cb7-4f3b-be72-ae783de82c42",
+      "sources": [
         {
           "set": "JMP",
           "set_name": "JumpStart 2020",
@@ -1051,6 +1129,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2",
       "sources": [
         {
           "set": "J22",
@@ -1065,16 +1147,29 @@
           "card": "Leonin Warleader"
         },
         {
-          "set": "J22",
-          "set_name": "JumpStart 2022",
-          "deck": "HOLY (4)",
-          "card": "Attended Healer"
-        },
-        {
           "set": "J25",
           "set_name": "JumpStart Foundations",
           "deck": "STALWART (1)",
           "card": "Ajani, Adversary of Tyrants"
+        }
+      ]
+    },
+    {
+      "name": "Cat",
+      "type_line": "Token Creature — Cat",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (4)",
+          "card": "Attended Healer"
         },
         {
           "set": "FDN",
@@ -1092,6 +1187,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "8050907b-4007-4478-8ebd-25b8b2bf85c3",
       "sources": [
         {
           "set": "J22",
@@ -1109,6 +1206,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "53c009a1-b9b6-43d6-8543-77688fedf8ae",
       "sources": [
         {
           "set": "J25",
@@ -1122,6 +1223,8 @@
       "name": "Clue",
       "type_line": "Token Artifact — Clue",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e",
       "sources": [
         {
           "set": "J22",
@@ -1709,6 +1812,10 @@
       ],
       "power": "3",
       "toughness": "1",
+      "keywords": [
+        "Haste"
+      ],
+      "oracle_id": "74658c70-caa8-4172-8a65-055d327668f9",
       "sources": [
         {
           "set": "J22",
@@ -1722,6 +1829,8 @@
       "name": "Copy",
       "type_line": "Token",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70",
       "sources": [
         {
           "set": "J22",
@@ -1931,6 +2040,10 @@
       ],
       "power": "5",
       "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308",
       "sources": [
         {
           "set": "JMP",
@@ -1978,6 +2091,10 @@
       ],
       "power": "*",
       "toughness": "*",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "0f6d78a4-f330-47b5-9c30-51324a1e7fb9",
       "sources": [
         {
           "set": "J22",
@@ -1995,6 +2112,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7",
       "sources": [
         {
           "set": "JMP",
@@ -2036,6 +2155,10 @@
       ],
       "power": "3",
       "toughness": "3",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "240300bd-5088-43c5-a873-290507515843",
       "sources": [
         {
           "set": "JMP",
@@ -2071,6 +2194,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148",
       "sources": [
         {
           "set": "JMP",
@@ -2106,6 +2231,10 @@
       ],
       "power": "5",
       "toughness": "5",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b",
       "sources": [
         {
           "set": "JMP",
@@ -2147,6 +2276,10 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "ec6df381-5ea7-4c68-8416-093b107f0784",
       "sources": [
         {
           "set": "J22",
@@ -2164,6 +2297,10 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a",
       "sources": [
         {
           "set": "JMP",
@@ -2233,6 +2370,8 @@
       "colors": [],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833",
       "sources": [
         {
           "set": "J22",
@@ -2262,6 +2401,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257",
       "sources": [
         {
           "set": "JMP",
@@ -2304,18 +2445,6 @@
           "set_name": "JumpStart Foundations",
           "deck": "STOKED (4)",
           "card": "Young Pyromancer"
-        },
-        {
-          "set": "MOM",
-          "set_name": "March of the Machine",
-          "deck": "OVERACHIEVER 1",
-          "card": "Preening Champion"
-        },
-        {
-          "set": "MOM",
-          "set_name": "March of the Machine",
-          "deck": "REINFORCEMENT 1",
-          "card": "Ral's Reinforcements"
         }
       ]
     },
@@ -2327,6 +2456,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716",
       "sources": [
         {
           "set": "JMP",
@@ -2350,18 +2481,16 @@
       ],
       "power": "*",
       "toughness": "*",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "74a3dea1-6a43-4cd2-925e-0abcf076bd02",
       "sources": [
         {
           "set": "J22",
           "set_name": "JumpStart 2022",
           "deck": "EXPERIMENTAL (1)",
           "card": "Seize the Storm"
-        },
-        {
-          "set": "CLU",
-          "set_name": "Ravnica: Clue Edition",
-          "deck": "SELESNYA CONCLAVE 2",
-          "card": "Vernal Sovereign"
         }
       ]
     },
@@ -2374,6 +2503,8 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [],
+      "oracle_id": "f81c047d-de36-4aed-806b-f14a290771a4",
       "sources": [
         {
           "set": "J22",
@@ -2391,12 +2522,62 @@
       ],
       "power": "7",
       "toughness": "7",
+      "keywords": [
+        "Trample"
+      ],
+      "oracle_id": "ab19c684-94c6-4491-8a6b-7f31dddadae6",
       "sources": [
         {
           "set": "J25",
           "set_name": "JumpStart Foundations",
           "deck": "ELVES (4)",
           "card": "Voice of the Woods"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "R",
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f",
+      "sources": [
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "OVERACHIEVER 1",
+          "card": "Preening Champion"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 1",
+          "card": "Ral's Reinforcements"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "G",
+        "W"
+      ],
+      "power": "*",
+      "toughness": "*",
+      "keywords": [],
+      "oracle_id": "9f790267-5be9-41aa-be69-f87a8ce5a29e",
+      "sources": [
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Vernal Sovereign"
         }
       ]
     },
@@ -2408,6 +2589,10 @@
       ],
       "power": "4",
       "toughness": "4",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "28cd830b-def6-4aa3-a0f6-6913bcdf931e",
       "sources": [
         {
           "set": "J25",
@@ -2425,6 +2610,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92",
       "sources": [
         {
           "set": "JMP",
@@ -2610,6 +2797,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac",
       "sources": [
         {
           "set": "J22",
@@ -2645,6 +2836,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0",
       "sources": [
         {
           "set": "J25",
@@ -2664,6 +2857,8 @@
       "name": "Food",
       "type_line": "Token Artifact — Food",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "a468338f-635e-4206-89d6-72d723071d45",
       "sources": [
         {
           "set": "JMP",
@@ -3017,6 +3212,8 @@
       ],
       "power": "3",
       "toughness": "3",
+      "keywords": [],
+      "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5",
       "sources": [
         {
           "set": "CLU",
@@ -3040,6 +3237,8 @@
       ],
       "power": "7",
       "toughness": "7",
+      "keywords": [],
+      "oracle_id": "33ec3894-6ec2-4038-bed4-85e5b9cfe182",
       "sources": [
         {
           "set": "J25",
@@ -3057,6 +3256,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8",
       "sources": [
         {
           "set": "JMP",
@@ -3368,6 +3569,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692",
       "sources": [
         {
           "set": "JMP",
@@ -3391,6 +3596,10 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a",
       "sources": [
         {
           "set": "JMP",
@@ -3426,6 +3635,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a",
       "sources": [
         {
           "set": "JMP",
@@ -3455,6 +3666,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a",
       "sources": [
         {
           "set": "J25",
@@ -3558,6 +3771,10 @@
       "name": "Incubator // Phyrexian",
       "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
       "colors": [],
+      "keywords": [
+        "Transform"
+      ],
+      "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253",
       "sources": [
         {
           "set": "MOM",
@@ -3671,6 +3888,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc",
       "sources": [
         {
           "set": "J22",
@@ -3713,7 +3932,22 @@
           "set_name": "JumpStart 2022",
           "deck": "INSECTS (4)",
           "card": "Crawling Sensation"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Insect",
+      "type_line": "Token Creature — Insect",
+      "colors": [
+        "B"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146",
+      "sources": [
         {
           "set": "J25",
           "set_name": "JumpStart Foundations",
@@ -3725,7 +3959,21 @@
           "set_name": "JumpStart Foundations",
           "deck": "ICKY (2)",
           "card": "Fumulus, the Infestation"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Insect",
+      "type_line": "Token Creature — Insect",
+      "colors": [
+        "B",
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "ea029c48-d26e-40b1-acef-2ec47fb61101",
+      "sources": [
         {
           "set": "CLU",
           "set_name": "Ravnica: Clue Edition",
@@ -3742,6 +3990,10 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8",
       "sources": [
         {
           "set": "JMP",
@@ -3820,7 +4072,23 @@
           "set_name": "JumpStart Foundations",
           "deck": "STALWART (2)",
           "card": "Basri's Lieutenant"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Knight",
+      "type_line": "Token Creature — Knight",
+      "colors": [
+        "U",
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "8d7d636d-4ae7-4411-8f45-fc57fead851e",
+      "sources": [
         {
           "set": "MOM",
           "set_name": "March of the Machine",
@@ -3837,6 +4105,11 @@
       ],
       "power": "20",
       "toughness": "20",
+      "keywords": [
+        "Flying",
+        "Indestructible"
+      ],
+      "oracle_id": "48e9147e-59f7-4693-83d7-7f514be871bc",
       "sources": [
         {
           "set": "J22",
@@ -3854,6 +4127,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Hexproof"
+      ],
+      "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c",
       "sources": [
         {
           "set": "J22",
@@ -3877,6 +4154,8 @@
       ],
       "power": "2",
       "toughness": "3",
+      "keywords": [],
+      "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9",
       "sources": [
         {
           "set": "JMP",
@@ -3912,6 +4191,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Prowess"
+      ],
+      "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d",
       "sources": [
         {
           "set": "TLA",
@@ -3935,6 +4218,8 @@
       ],
       "power": "0",
       "toughness": "0",
+      "keywords": [],
+      "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad",
       "sources": [
         {
           "set": "LTR",
@@ -4126,6 +4411,10 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d",
       "sources": [
         {
           "set": "J22",
@@ -4149,6 +4438,10 @@
       ],
       "power": "3",
       "toughness": "3",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b",
       "sources": [
         {
           "set": "ONE",
@@ -4178,6 +4471,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "b43340e3-bb76-4501-8db2-040b7cae33b7",
       "sources": [
         {
           "set": "ONE",
@@ -4193,6 +4488,10 @@
       "colors": [],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Toxic"
+      ],
+      "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b",
       "sources": [
         {
           "set": "ONE",
@@ -4244,6 +4543,8 @@
       "colors": [],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2",
       "sources": [
         {
           "set": "JMP",
@@ -4267,6 +4568,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18",
       "sources": [
         {
           "set": "JMP",
@@ -4290,6 +4593,8 @@
       ],
       "power": "0",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "bcd346a7-4d96-4a0c-9725-fb740e32b730",
       "sources": [
         {
           "set": "J22",
@@ -4303,6 +4608,8 @@
       "name": "Powerstone",
       "type_line": "Token Artifact — Powerstone",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664",
       "sources": [
         {
           "set": "BRO",
@@ -4398,6 +4705,8 @@
       ],
       "power": "2",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "e2a98673-a9c2-4579-b962-080405bbb661",
       "sources": [
         {
           "set": "J22",
@@ -4415,6 +4724,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626",
       "sources": [
         {
           "set": "JMP",
@@ -4444,6 +4755,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062",
       "sources": [
         {
           "set": "J25",
@@ -4521,6 +4834,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155",
       "sources": [
         {
           "set": "JMP",
@@ -4736,6 +5051,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Deathtouch"
+      ],
+      "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b",
       "sources": [
         {
           "set": "J22",
@@ -4757,6 +5076,8 @@
       "colors": [],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1",
       "sources": [
         {
           "set": "BRO",
@@ -4780,6 +5101,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d",
       "sources": [
         {
           "set": "JMP",
@@ -4856,12 +5179,6 @@
         {
           "set": "J22",
           "set_name": "JumpStart 2022",
-          "deck": "HOLY (3)",
-          "card": "Dawn of Hope"
-        },
-        {
-          "set": "J22",
-          "set_name": "JumpStart 2022",
           "deck": "LAW (2)",
           "card": "Decree of Justice"
         },
@@ -4926,30 +5243,6 @@
           "card": "Raise the Alarm"
         },
         {
-          "set": "J25",
-          "set_name": "JumpStart Foundations",
-          "deck": "STOKED (1)",
-          "card": "Frontline Heroism"
-        },
-        {
-          "set": "J25",
-          "set_name": "JumpStart Foundations",
-          "deck": "STOKED (3)",
-          "card": "Akroan Crusader"
-        },
-        {
-          "set": "J25",
-          "set_name": "JumpStart Foundations",
-          "deck": "STOKED (3)",
-          "card": "Frontline Heroism"
-        },
-        {
-          "set": "J25",
-          "set_name": "JumpStart Foundations",
-          "deck": "STOKED (4)",
-          "card": "Akroan Crusader"
-        },
-        {
           "set": "DMU",
           "set_name": "Dominaria United",
           "deck": "COALITION CORPS",
@@ -4972,6 +5265,27 @@
           "set_name": "Dominaria United",
           "deck": "COALITION LEGION",
           "card": "Argivian Cavalier"
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (3)",
+          "card": "Dawn of Hope"
         },
         {
           "set": "CLU",
@@ -4987,8 +5301,49 @@
       "colors": [
         "R"
       ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (1)",
+          "card": "Frontline Heroism"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (3)",
+          "card": "Akroan Crusader"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (3)",
+          "card": "Frontline Heroism"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (4)",
+          "card": "Akroan Crusader"
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "R"
+      ],
       "power": "2",
       "toughness": "2",
+      "keywords": [
+        "Firebending"
+      ],
+      "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e",
       "sources": [
         {
           "set": "TLA",
@@ -5031,13 +5386,41 @@
           "set_name": "Avatar: The Last Airbender",
           "deck": "ZUKO",
           "card": "Fire Nation Attacks"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "01e023e5-38bc-4203-aecb-6b2de54b03ea",
+      "sources": [
         {
           "set": "CLU",
           "set_name": "Ravnica: Clue Edition",
           "deck": "BOROS LEGION 1",
           "card": "Finale of Glory"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "keywords": [],
+      "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1",
+      "sources": [
         {
           "set": "TLB",
           "set_name": "Avatar TLA Beginner Box",
@@ -5060,6 +5443,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c",
       "sources": [
         {
           "set": "J22",
@@ -5140,6 +5527,29 @@
           "card": "Sandsteppe Outcast"
         },
         {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Doomed Traveler"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Transluminant"
+        }
+      ]
+    },
+    {
+      "name": "Spirit",
+      "type_line": "Token Creature — Spirit",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [],
+      "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564",
+      "sources": [
+        {
           "set": "TLA",
           "set_name": "Avatar: The Last Airbender",
           "deck": "ADAPTIVE",
@@ -5176,6 +5586,28 @@
           "card": "Lost in the Spirit World"
         },
         {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "SPELLS",
+          "card": "Lost in the Spirit World"
+        }
+      ]
+    },
+    {
+      "name": "Spirit",
+      "type_line": "Token Creature — Spirit",
+      "colors": [
+        "B",
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04",
+      "sources": [
+        {
           "set": "CLU",
           "set_name": "Ravnica: Clue Edition",
           "deck": "ORZHOV SYNDICATE 1",
@@ -5204,24 +5636,6 @@
           "set_name": "Ravnica: Clue Edition",
           "deck": "ORZHOV SYNDICATE 2",
           "card": "Seraph of the Scales"
-        },
-        {
-          "set": "CLU",
-          "set_name": "Ravnica: Clue Edition",
-          "deck": "SELESNYA CONCLAVE 1",
-          "card": "Doomed Traveler"
-        },
-        {
-          "set": "CLU",
-          "set_name": "Ravnica: Clue Edition",
-          "deck": "SELESNYA CONCLAVE 2",
-          "card": "Transluminant"
-        },
-        {
-          "set": "TLB",
-          "set_name": "Avatar TLA Beginner Box",
-          "deck": "SPELLS",
-          "card": "Lost in the Spirit World"
         }
       ]
     },
@@ -5233,6 +5647,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "82adaeee-e011-49db-af53-fda6c2b192d5",
       "sources": [
         {
           "set": "J25",
@@ -5250,13 +5666,30 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "e3c8482e-ce21-43f8-ac07-c26c01941a4d",
       "sources": [
         {
           "set": "JMP",
           "set_name": "JumpStart 2020",
           "deck": "ARCHAEOLOGY (3)",
           "card": "Sharding Sphinx"
-        },
+        }
+      ]
+    },
+    {
+      "name": "Thopter",
+      "type_line": "Token Artifact Creature — Thopter",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "keywords": [
+        "Flying"
+      ],
+      "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f",
+      "sources": [
         {
           "set": "J22",
           "set_name": "JumpStart 2022",
@@ -5431,6 +5864,8 @@
       "name": "Treasure",
       "type_line": "Token Artifact — Treasure",
       "colors": [],
+      "keywords": [],
+      "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d",
       "sources": [
         {
           "set": "JMP",
@@ -5946,6 +6381,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Lifelink"
+      ],
+      "oracle_id": "97af46cb-6209-4ae7-81cc-792894999937",
       "sources": [
         {
           "set": "J25",
@@ -5963,6 +6402,10 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [
+        "Vigilance"
+      ],
+      "oracle_id": "4bd91cb2-be86-4950-8b84-7b330a8a61b9",
       "sources": [
         {
           "set": "J25",
@@ -5980,6 +6423,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f",
       "sources": [
         {
           "set": "J22",
@@ -6003,6 +6448,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b",
       "sources": [
         {
           "set": "J22",
@@ -6129,6 +6576,8 @@
       ],
       "power": "1",
       "toughness": "1",
+      "keywords": [],
+      "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6",
       "sources": [
         {
           "set": "J25",
@@ -6156,6 +6605,8 @@
       "colors": [],
       "power": "3",
       "toughness": "3",
+      "keywords": [],
+      "oracle_id": "82868a85-a6f4-47db-b159-d23a9c4c9892",
       "sources": [
         {
           "set": "BRO",
@@ -6173,6 +6624,8 @@
       ],
       "power": "2",
       "toughness": "2",
+      "keywords": [],
+      "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362",
       "sources": [
         {
           "set": "JMP",

--- a/etc/jumpstart-token-index.json
+++ b/etc/jumpstart-token-index.json
@@ -1,0 +1,6462 @@
+{
+  "metadata": {
+    "generated": "2026-04-26T21:13:00.047620+00:00",
+    "total_tokens": 86,
+    "total_source_refs": 922,
+    "decks_scanned": 529,
+    "sets": [
+      "JMP",
+      "J22",
+      "J25",
+      "TLA",
+      "ONE",
+      "DMU",
+      "BRO",
+      "MOM",
+      "LTR",
+      "CLU",
+      "FDN",
+      "TLB"
+    ]
+  },
+  "tokens": [
+    {
+      "name": "Ajani's Pridemate",
+      "type_line": "Token Creature — Cat Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CATS (3)",
+          "card": "Ajani, Strength of the Pride"
+        }
+      ]
+    },
+    {
+      "name": "Ally",
+      "type_line": "Token Creature — Ally",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AANG",
+          "card": "Aang, Airbending Master"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AANG",
+          "card": "Invasion Reinforcements"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AANG",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AANG",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ADAPTIVE",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AIRBENDING",
+          "card": "Invasion Reinforcements"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AIRBENDING",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (1)",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (1)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (1)",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (2)",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (2)",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH KINGDOM (1)",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH KINGDOM (1)",
+          "card": "Match the Odds"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH KINGDOM (1)",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH KINGDOM (2)",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH RUMBLE (1)",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH RUMBLE (2)",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (1)",
+          "card": "Loyal Fire Sage"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (2)",
+          "card": "Loyal Fire Sage"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FREEDOM FIGHTERS",
+          "card": "Hook Swords"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FREEDOM FIGHTERS",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "GLIDING (1)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "GLIDING (2)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (1)",
+          "card": "Invasion Reinforcements"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (1)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (1)",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (1)",
+          "card": "Suki, Courageous Rescuer"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (2)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (2)",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (2)",
+          "card": "Suki, Courageous Rescuer"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "INSURGENT (1)",
+          "card": "Invasion Reinforcements"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "INSURGENT (1)",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "INSURGENT (2)",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "INSURGENT (2)",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "KYOSHI",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "KYOSHI",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "MUSICIANS",
+          "card": "Founding of Omashu"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "MUSICIANS",
+          "card": "The Cave of Two Lovers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "NIGHTMARES",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REBELLING (1)",
+          "card": "Treetop Freedom Fighters"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REBELLING (2)",
+          "card": "Hook Swords"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REBELLING (2)",
+          "card": "Treetop Freedom Fighters"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ROKU",
+          "card": "Loyal Fire Sage"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SIEGE ENGINES",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SWORDMASTER",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WARRIORS",
+          "card": "Invasion Reinforcements"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WARRIORS",
+          "card": "Kyoshi Battle Fan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WARRIORS",
+          "card": "Kyoshi Warriors"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WARRIORS",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "AANG TUTORIAL",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "ALLIES",
+          "card": "Allied Teamwork"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "ALLIES",
+          "card": "Path to Redemption"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "ALLIES",
+          "card": "Suki, Kyoshi Warrior"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "ATTACKING",
+          "card": "Pretending Poxbearers"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "BIG CREATURES",
+          "card": "Match the Odds"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "FIREBENDING",
+          "card": "Loyal Fire Sage"
+        }
+      ]
+    },
+    {
+      "name": "Angel",
+      "type_line": "Token Creature — Angel",
+      "colors": [
+        "W"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ANGELS (1)",
+          "card": "Angelic Ascension"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ANGELS (2)",
+          "card": "Angelic Ascension"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (1)",
+          "card": "Speaker of the Heavens"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (2)",
+          "card": "Speaker of the Heavens"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "FEATHERED FRIENDS (2)",
+          "card": "Angelic Ascension"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CONSTELLATION (2)",
+          "card": "Sigil of the Empty Throne"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (3)",
+          "card": "Valkyrie Harbinger"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LAW (2)",
+          "card": "Decree of Justice"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "HEALERS (1)",
+          "card": "Speaker of the Heavens"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "HEALERS (2)",
+          "card": "Valkyrie Harbinger"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "BOROS LEGION 1",
+          "card": "Finale of Glory"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Urbis Protector"
+        }
+      ]
+    },
+    {
+      "name": "Angel Warrior",
+      "type_line": "Token Creature — Angel Warrior",
+      "colors": [
+        "W"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (1)",
+          "card": "Valkyrie's Sword"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (3)",
+          "card": "Valkyrie's Sword"
+        }
+      ]
+    },
+    {
+      "name": "Assembly-Worker",
+      "type_line": "Token Artifact Creature — Assembly-Worker",
+      "colors": [],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "URZA'S",
+          "card": "Urza's Factory"
+        }
+      ]
+    },
+    {
+      "name": "Ballistic Boulder",
+      "type_line": "Token Artifact Creature — Construct",
+      "colors": [],
+      "power": "2",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AZULA",
+          "card": "Fire Navy Trebuchet"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Fire Navy Trebuchet"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "OZAI",
+          "card": "Fire Navy Trebuchet"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SIEGE ENGINES",
+          "card": "Fire Navy Trebuchet"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Mordor Trebuchet"
+        }
+      ]
+    },
+    {
+      "name": "Bat",
+      "type_line": "Token Creature — Bat",
+      "colors": [
+        "B"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GOLGARI SWARM 1",
+          "card": "Leering Onlooker"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 2",
+          "card": "Leering Onlooker"
+        }
+      ]
+    },
+    {
+      "name": "Bear",
+      "type_line": "Token Creature — Bear",
+      "colors": [
+        "G"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH RUMBLE (2)",
+          "card": "The Earth King"
+        }
+      ]
+    },
+    {
+      "name": "Beast",
+      "type_line": "Token Creature — Beast",
+      "colors": [
+        "G"
+      ],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GARRUK",
+          "card": "Garruk, Unleashed"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PLUS ONE (1)",
+          "card": "Primeval Bounty"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (3)",
+          "card": "Thragtusk"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ENCOUNTER (4)",
+          "card": "Primeval Bounty"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Somberwald Beastmaster"
+        }
+      ]
+    },
+    {
+      "name": "Beast",
+      "type_line": "Token Creature — Beast",
+      "colors": [
+        "G"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LANDFALL (1)",
+          "card": "Rampaging Baloths"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Somberwald Beastmaster"
+        }
+      ]
+    },
+    {
+      "name": "Bird",
+      "type_line": "Token Creature — Bird",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "FEATHERED FRIENDS (1)",
+          "card": "Falconer Adept"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "FEATHERED FRIENDS (2)",
+          "card": "Falconer Adept"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "FEATHERED FRIENDS (3)",
+          "card": "Falconer Adept"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "FEATHERED FRIENDS (4)",
+          "card": "Falconer Adept"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (1)",
+          "card": "Falconer Adept"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (4)",
+          "card": "Seller of Songbirds"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "WIZARDS (2)",
+          "card": "Aether Channeler"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION CORPS",
+          "card": "Love Song of Night and Day"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION LEGION",
+          "card": "Love Song of Night and Day"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Seller of Songbirds"
+        }
+      ]
+    },
+    {
+      "name": "Bird Illusion",
+      "type_line": "Token Creature — Bird Illusion",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ILLUSIONS",
+          "card": "Murmuring Mystic"
+        }
+      ]
+    },
+    {
+      "name": "Blood",
+      "type_line": "Token Artifact — Blood",
+      "colors": [],
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (1)",
+          "card": "Belligerent Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (1)",
+          "card": "Blood Petal Celebrant"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (1)",
+          "card": "Falkenrath Celebrants"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (1)",
+          "card": "Ivora, Insatiable Heir"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (1)",
+          "card": "Voldaren Epicure"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (2)",
+          "card": "Blood Petal Celebrant"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (2)",
+          "card": "Falkenrath Celebrants"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (2)",
+          "card": "Ivora, Insatiable Heir"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (2)",
+          "card": "Markov Enforcer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (3)",
+          "card": "Belligerent Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (3)",
+          "card": "Blood Petal Celebrant"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (3)",
+          "card": "Falkenrath Celebrants"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (3)",
+          "card": "Ivora, Insatiable Heir"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (4)",
+          "card": "Belligerent Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (4)",
+          "card": "Blood Petal Celebrant"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (4)",
+          "card": "Falkenrath Celebrants"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (4)",
+          "card": "Ivora, Insatiable Heir"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (4)",
+          "card": "Voldaren Epicure"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (1)",
+          "card": "Blood Fountain"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (1)",
+          "card": "Gluttonous Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (2)",
+          "card": "Blood Fountain"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (2)",
+          "card": "Gluttonous Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (3)",
+          "card": "Blood Fountain"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (3)",
+          "card": "Gluttonous Guest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (4)",
+          "card": "Blood Fountain"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "VAMPIRES (4)",
+          "card": "Gluttonous Guest"
+        }
+      ]
+    },
+    {
+      "name": "Boar",
+      "type_line": "Token Creature — Boar",
+      "colors": [
+        "G"
+      ],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (1)",
+          "card": "Brindle Shoat"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (2)",
+          "card": "Brindle Shoat"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (3)",
+          "card": "Brindle Shoat"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (4)",
+          "card": "Brindle Shoat"
+        }
+      ]
+    },
+    {
+      "name": "Boar",
+      "type_line": "Token Creature — Boar",
+      "colors": [
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Wolf's Quarry"
+        }
+      ]
+    },
+    {
+      "name": "Boar",
+      "type_line": "Token Creature — Boar",
+      "colors": [
+        "G"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GRUUL CLANS 2",
+          "card": "Stampede Surfer"
+        }
+      ]
+    },
+    {
+      "name": "Butterfly",
+      "type_line": "Token Creature — Insect",
+      "colors": [
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (4)",
+          "card": "Giant Caterpillar"
+        }
+      ]
+    },
+    {
+      "name": "Cat",
+      "type_line": "Token Creature — Cat",
+      "colors": [
+        "B"
+      ],
+      "power": "2",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "CATS (2)",
+          "card": "Penumbra Bobcat"
+        }
+      ]
+    },
+    {
+      "name": "Cat",
+      "type_line": "Token Creature — Cat",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ENCHANTED (2)",
+          "card": "Ajani's Chosen"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TREE-HUGGING (3)",
+          "card": "Jolrael, Mwonvuli Recluse"
+        }
+      ]
+    },
+    {
+      "name": "Cat",
+      "type_line": "Token Creature — Cat",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CATS (1)",
+          "card": "Regal Caracal"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CATS (4)",
+          "card": "Leonin Warleader"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (4)",
+          "card": "Attended Healer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (1)",
+          "card": "Ajani, Adversary of Tyrants"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "CATS",
+          "card": "Prideful Parent"
+        }
+      ]
+    },
+    {
+      "name": "Cat Beast",
+      "type_line": "Token Creature — Cat Beast",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CATS (2)",
+          "card": "Felidar Retreat"
+        }
+      ]
+    },
+    {
+      "name": "Cat Soldier",
+      "type_line": "Token Creature — Cat Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "PRIDEFUL",
+          "card": "Brimaz, King of Oreskos"
+        }
+      ]
+    },
+    {
+      "name": "Clue",
+      "type_line": "Token Artifact — Clue",
+      "colors": [],
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (1)",
+          "card": "Thraben Inspector"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Drownyard Explorers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Floodhound"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Hold for Questioning"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Jace's Scrutiny"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Magnifying Glass"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Press for Answers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Drownyard Explorers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Floodhound"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Hold for Questioning"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Jace's Scrutiny"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Magnifying Glass"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (2)",
+          "card": "Press for Answers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Drownyard Explorers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Floodhound"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Hold for Questioning"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Jace's Scrutiny"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Magnifying Glass"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Press for Answers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Drownyard Explorers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Erdwal Illuminator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Floodhound"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Hold for Questioning"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Jace's Scrutiny"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Magnifying Glass"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Press for Answers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Tamiyo's Journal"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (2)",
+          "card": "Byway Courier"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (2)",
+          "card": "Tireless Tracker"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (2)",
+          "card": "Ulvenwald Mysteries"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Briarbridge Tracker"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Byway Courier"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Ulvenwald Mysteries"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (1)",
+          "card": "Foul Play"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (2)",
+          "card": "Foul Play"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ADEPT (1)",
+          "card": "Forecasting Fortune Teller"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ADEPT (2)",
+          "card": "Lost Days"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ALLIANCE (1)",
+          "card": "Sokka's Sword Training"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AZULA",
+          "card": "Sold Out"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BAD ADVICE",
+          "card": "Sold Out"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "Azula, On the Hunt"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "June, Bounty Hunter"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "Nyla, Shirshu Sleuth"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "Sold Out"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Azula, On the Hunt"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Callous Inspector"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "June, Bounty Hunter"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Nyla, Shirshu Sleuth"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Obsessive Pursuit"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Sold Out"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIRE NATION",
+          "card": "Cunning Maneuver"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (1)",
+          "card": "Cunning Maneuver"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (2)",
+          "card": "Cunning Maneuver"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HEI BAI (2)",
+          "card": "Sokka's Sword Training"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (1)",
+          "card": "June, Bounty Hunter"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (1)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (1)",
+          "card": "Raven Eagle"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (2)",
+          "card": "June, Bounty Hunter"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (2)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "HUNTING (2)",
+          "card": "Raven Eagle"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LEARNING (1)",
+          "card": "Zuko's Exile"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LEARNING (2)",
+          "card": "True Ancestry"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LEARNING (2)",
+          "card": "Zuko's Exile"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LESSONS (2)",
+          "card": "Lost Days"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LIBRARIAN",
+          "card": "Knowledge Seeker"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LIBRARIAN",
+          "card": "Zuko's Exile"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "MUSICIANS",
+          "card": "Cunning Maneuver"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "NIGHTMARES",
+          "card": "Azula, On the Hunt"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "OZAI",
+          "card": "Callous Inspector"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "POWERFUL (1)",
+          "card": "Fire Nation Raider"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "POWERFUL (2)",
+          "card": "Fire Nation Raider"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REBELLING (1)",
+          "card": "Cunning Maneuver"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REINFORCED (1)",
+          "card": "Callous Inspector"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (1)",
+          "card": "Azula, On the Hunt"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (1)",
+          "card": "Sold Out"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (2)",
+          "card": "Azula, On the Hunt"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (2)",
+          "card": "Callous Inspector"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SIEGE ENGINES",
+          "card": "Callous Inspector"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SIEGE ENGINES",
+          "card": "Fire Nation Warship"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SOARING (1)",
+          "card": "Forecasting Fortune Teller"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SOARING (1)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SOARING (1)",
+          "card": "The Mechanist, Aerial Artisan"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SOARING (2)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SPIRIT",
+          "card": "Knowledge Seeker"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SWORDMASTER",
+          "card": "Sokka's Sword Training"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WARRIORS",
+          "card": "Sokka's Sword Training"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WISE (1)",
+          "card": "Forecasting Fortune Teller"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WISE (1)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WISE (2)",
+          "card": "Knowledge Seeker"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "WISE (2)",
+          "card": "Messenger Hawk"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "AZORIUS SENATE 1",
+          "card": "Lavinia, Foil to Conspiracy"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "BOROS LEGION 1",
+          "card": "Novice Inspector"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "CULT OF RAKDOS 2",
+          "card": "Carnage Interpreter"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "IZZET LEAGUE 1",
+          "card": "Resonance Technician"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 1",
+          "card": "Syndicate Heavy"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SIMIC COMBINE 2",
+          "card": "Lonis, Genetics Expert"
+        }
+      ]
+    },
+    {
+      "name": "Construct",
+      "type_line": "Token Artifact Creature — Construct",
+      "colors": [
+        "R"
+      ],
+      "power": "3",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Sokenzan Smelter"
+        }
+      ]
+    },
+    {
+      "name": "Copy",
+      "type_line": "Token",
+      "colors": [],
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (1)",
+          "card": "Preston, the Vanisher"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (3)",
+          "card": "Preston, the Vanisher"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (1)",
+          "card": "Mechanized Production"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (3)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DETECTIVE (4)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (4)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "EXPERIMENTAL (1)",
+          "card": "Mizzix, Replica Rider"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "EXPERIMENTAL (2)",
+          "card": "Mizzix, Replica Rider"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (4)",
+          "card": "Cogwork Assembler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (4)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPEEDY",
+          "card": "Kiki-Jiki, Mirror Breaker"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Dutiful Replicator"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BURNING",
+          "card": "Rionya, Fire Dancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DROWNED (2)",
+          "card": "Cackling Counterpart"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GIDDYAP",
+          "card": "Thurid, Mare of Destiny"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ZEALOTS (2)",
+          "card": "Sandstorm Crasher"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ZEALOTS (4)",
+          "card": "Sandstorm Crasher"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BAD ADVICE",
+          "card": "Joo Dee, One of Many"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "NIGHTMARES",
+          "card": "Joo Dee, One of Many"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (2)",
+          "card": "Joo Dee, One of Many"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "CORRUPTION (1)",
+          "card": "Kinzu of the Bleak Coven"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "CORRUPTION (2)",
+          "card": "Kinzu of the Bleak Coven"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 1",
+          "card": "Orthion, Hero of Lavabrink"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 2",
+          "card": "Orthion, Hero of Lavabrink"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GRUUL CLANS 2",
+          "card": "Giant Adephage"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "IZZET LEAGUE 2",
+          "card": "Corporeal Projection"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Conclave Evangelist"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Sumala Rumblers"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Sumala Rumblers"
+        }
+      ]
+    },
+    {
+      "name": "Demon",
+      "type_line": "Token Creature — Demon",
+      "colors": [
+        "B"
+      ],
+      "power": "5",
+      "toughness": "5",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "REANIMATED (1)",
+          "card": "Archfiend's Vessel"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (2)",
+          "card": "Priest of the Blood Rite"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (2)",
+          "card": "Skirsdag High Priest"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "CLERICS (1)",
+          "card": "Archfiend's Vessel"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "CLERICS (2)",
+          "card": "Archfiend's Vessel"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "CLERICS (4)",
+          "card": "Archfiend's Vessel"
+        }
+      ]
+    },
+    {
+      "name": "Demon",
+      "type_line": "Token Creature — Demon",
+      "colors": [
+        "B"
+      ],
+      "power": "*",
+      "toughness": "*",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "FANGS (3)",
+          "card": "Tivash, Gloom Summoner"
+        }
+      ]
+    },
+    {
+      "name": "Devil",
+      "type_line": "Token Creature — Devil",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DEVILISH (1)",
+          "card": "Dance with Devils"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DEVILISH (1)",
+          "card": "Zurzoth, Chaos Rider"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DEVILISH (2)",
+          "card": "Zurzoth, Chaos Rider"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DEVILISH (3)",
+          "card": "Dance with Devils"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "FIERY (3)",
+          "card": "Dance with Devils"
+        }
+      ]
+    },
+    {
+      "name": "Dinosaur",
+      "type_line": "Token Creature — Dinosaur",
+      "colors": [
+        "G"
+      ],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DINOSAURS (2)",
+          "card": "Thundering Spineback"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DINOSAURS (3)",
+          "card": "Thundering Spineback"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINOSAURS (1)",
+          "card": "Thundering Spineback"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINOSAURS (2)",
+          "card": "Thundering Spineback"
+        }
+      ]
+    },
+    {
+      "name": "Dog",
+      "type_line": "Token Creature — Dog",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOGS (1)",
+          "card": "Release the Dogs"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOGS (2)",
+          "card": "Release the Dogs"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (2)",
+          "card": "Release the Dogs"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (3)",
+          "card": "Release the Dogs"
+        }
+      ]
+    },
+    {
+      "name": "Dragon",
+      "type_line": "Token Creature — Dragon",
+      "colors": [
+        "R"
+      ],
+      "power": "5",
+      "toughness": "5",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (2)",
+          "card": "Lathliss, Dragon Queen"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DRAGONS (2)",
+          "card": "Lathliss, Dragon Queen"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (1)",
+          "card": "Lathliss, Dragon Queen"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (2)",
+          "card": "Lathliss, Dragon Queen"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (2)",
+          "card": "Sarkhan, Fireblood"
+        }
+      ]
+    },
+    {
+      "name": "Dragon",
+      "type_line": "Token Creature — Dragon",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DRAGONS (1)",
+          "card": "Dragon Egg"
+        }
+      ]
+    },
+    {
+      "name": "Drake",
+      "type_line": "Token Creature — Drake",
+      "colors": [
+        "U"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ABOVE THE CLOUDS (2)",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TEFERI",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (1)",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (1)",
+          "card": "Talrand, Sky Summoner"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (2)",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (3)",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (3)",
+          "card": "Talrand, Sky Summoner"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WIZARDS (4)",
+          "card": "Talrand's Invocation"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "THINK AGAIN (2)",
+          "card": "Alandra, Sky Dreamer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "THINK AGAIN (3)",
+          "card": "Alandra, Sky Dreamer"
+        }
+      ]
+    },
+    {
+      "name": "Eldrazi Scion",
+      "type_line": "Token Creature — Eldrazi Scion",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELDRAZI",
+          "card": "Blisterpod"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELDRAZI",
+          "card": "Brood Monitor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELDRAZI",
+          "card": "Scion Summoner"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "CHANDRA",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPELLCASTING (2)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "EXPERIMENTAL (1)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "COPIED (1)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "COPIED (2)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (3)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (4)",
+          "card": "Young Pyromancer"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "OVERACHIEVER 1",
+          "card": "Preening Champion"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 1",
+          "card": "Ral's Reinforcements"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "G"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LANDS (1)",
+          "card": "Zendikar's Roil"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LANDFALL (1)",
+          "card": "Zendikar's Roil"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "R"
+      ],
+      "power": "*",
+      "toughness": "*",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "EXPERIMENTAL (1)",
+          "card": "Seize the Storm"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Vernal Sovereign"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "R",
+        "U"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GO TO SCHOOL (2)",
+          "card": "Multiple Choice"
+        }
+      ]
+    },
+    {
+      "name": "Elemental",
+      "type_line": "Token Creature — Elemental",
+      "colors": [
+        "G"
+      ],
+      "power": "7",
+      "toughness": "7",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ELVES (4)",
+          "card": "Voice of the Woods"
+        }
+      ]
+    },
+    {
+      "name": "Elemental Bird",
+      "type_line": "Token Creature — Elemental Bird",
+      "colors": [
+        "U"
+      ],
+      "power": "4",
+      "toughness": "4",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "SOARING (3)",
+          "card": "Mu Yanling, Sky Dancer"
+        }
+      ]
+    },
+    {
+      "name": "Elf Warrior",
+      "type_line": "Token Creature — Elf Warrior",
+      "colors": [
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ELVES (1)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ELVES (1)",
+          "card": "Presence of Gond"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ELVES (2)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ELVES (2)",
+          "card": "Presence of Gond"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TREE-HUGGING (1)",
+          "card": "Ambassador Oak"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TREE-HUGGING (2)",
+          "card": "Ambassador Oak"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TREE-HUGGING (3)",
+          "card": "Ambassador Oak"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (1)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (1)",
+          "card": "Elderleaf Mentor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (1)",
+          "card": "Elven Bow"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (1)",
+          "card": "Elvish Warmaster"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (2)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (2)",
+          "card": "Elderleaf Mentor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (2)",
+          "card": "Elven Bow"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (2)",
+          "card": "Imperious Perfect"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (3)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (3)",
+          "card": "Elderleaf Mentor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (3)",
+          "card": "Elven Bow"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (3)",
+          "card": "Lys Alana Huntmaster"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (3)",
+          "card": "Wolverine Riders"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (4)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (4)",
+          "card": "Elderleaf Mentor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (4)",
+          "card": "Elven Bow"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ELVES (4)",
+          "card": "Presence of Gond"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ELVES (2)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ELVES (3)",
+          "card": "Dwynen's Elite"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ELVES (4)",
+          "card": "Tyvar Kell"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Ambassador Oak"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "ELVES",
+          "card": "Dwynen's Elite"
+        }
+      ]
+    },
+    {
+      "name": "Faerie",
+      "type_line": "Token Creature — Faerie",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "FAERIES (2)",
+          "card": "Stolen by the Fae"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "THINK AGAIN (4)",
+          "card": "Faerie Formation"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "SOARING (4)",
+          "card": "Stolen by the Fae"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "WIZARDS",
+          "card": "Mischievous Mystic"
+        }
+      ]
+    },
+    {
+      "name": "Fish",
+      "type_line": "Token Creature — Fish",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DROWNED (1)",
+          "card": "Expendable Lackey"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DROWNED (2)",
+          "card": "Expendable Lackey"
+        }
+      ]
+    },
+    {
+      "name": "Food",
+      "type_line": "Token Artifact — Food",
+      "colors": [],
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WITCHCRAFT (1)",
+          "card": "Bake into a Pie"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WITCHCRAFT (1)",
+          "card": "Tempting Witch"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WITCHCRAFT (2)",
+          "card": "Bake into a Pie"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "WITCHCRAFT (2)",
+          "card": "Tempting Witch"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Fierce Witchstalker"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Fierce Witchstalker"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Giant Opportunity"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Hurska Sweet-Tooth"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Orchard Strider"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Tireless Provisioner"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Tough Cookie"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Trail of Crumbs"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (1)",
+          "card": "Tireless Provisioner"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AT THE ZOO",
+          "card": "Elephant-Mandrill"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "AZULA",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BUMI",
+          "card": "Bumi's Feast Lecture"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BUMI",
+          "card": "Creeping Crystal Coating"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Bosco, Just a Bear"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Bumi's Feast Lecture"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Elephant-Mandrill"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Leaves from the Vine"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Many Partings"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "The Art of Tea"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "The Cabbage Merchant"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "CABBAGES",
+          "card": "Unlucky Cabbage Merchant"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "EARTH RUMBLE (2)",
+          "card": "Bosco, Just a Bear"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "KYOSHI",
+          "card": "Elephant-Mandrill"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LEARNING (2)",
+          "card": "The Art of Tea"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "NIGHTMARES",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "OZAI",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (1)",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (2)",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SIEGE ENGINES",
+          "card": "Canyon Crawler"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "COURAGEOUS 1",
+          "card": "Bill the Pony"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "COURAGEOUS 1",
+          "card": "Rosie Cotton of South Lane"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "COURAGEOUS 2",
+          "card": "Bill the Pony"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "COURAGEOUS 2",
+          "card": "Eastfarthing Farmer"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "COURAGEOUS 2",
+          "card": "Rosie Cotton of South Lane"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ELVEN 1",
+          "card": "Stew the Coneys"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ELVEN 2",
+          "card": "Revive the Shire"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ELVEN 2",
+          "card": "Stew the Coneys"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 1",
+          "card": "Brandywine Farmer"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 1",
+          "card": "Elanor Gardner"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 1",
+          "card": "Meriadoc Brandybuck"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 1",
+          "card": "Revive the Shire"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Brandywine Farmer"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Elanor Gardner"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Meriadoc Brandybuck"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Peregrin Took"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Revive the Shire"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "JOURNEY 2",
+          "card": "Stew the Coneys"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 1",
+          "card": "Cirith Ungol Patrol"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 1",
+          "card": "Shelob's Ambush"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Cirith Ungol Patrol"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORTALS 1",
+          "card": "Eastfarthing Farmer"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORTALS 1",
+          "card": "Second Breakfast"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Voracious Fell Beast"
+        }
+      ]
+    },
+    {
+      "name": "Frog Lizard",
+      "type_line": "Token Creature — Frog Lizard",
+      "colors": [
+        "G"
+      ],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SIMIC COMBINE 1",
+          "card": "Rapid Hybridization"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SIMIC COMBINE 2",
+          "card": "Incubation"
+        }
+      ]
+    },
+    {
+      "name": "Giant",
+      "type_line": "Token Creature — Giant",
+      "colors": [
+        "G"
+      ],
+      "power": "7",
+      "toughness": "7",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Giant Opportunity"
+        }
+      ]
+    },
+    {
+      "name": "Goblin",
+      "type_line": "Token Creature — Goblin",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (1)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (2)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (1)",
+          "card": "Beetleback Chief"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (1)",
+          "card": "Goblin Instigator"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (2)",
+          "card": "Beetleback Chief"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (2)",
+          "card": "Goblin Instigator"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (3)",
+          "card": "Beetleback Chief"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (3)",
+          "card": "Goblin Instigator"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Instigator"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Rally"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "GOBLINS (4)",
+          "card": "Krenko, Mob Boss"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPELLCASTING (3)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DRAGONS (1)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (1)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (1)",
+          "card": "Hordeling Outburst"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (1)",
+          "card": "Krenko, Mob Boss"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (2)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (2)",
+          "card": "Goblin Rally"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (2)",
+          "card": "Ib Halfheart, Goblin Tactician"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (3)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (4)",
+          "card": "Ardoz, Cobbler of War"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (4)",
+          "card": "Dragon Fodder"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Rabblemaster"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Rally"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GOBLINS (4)",
+          "card": "Hordeling Outburst"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPEEDY",
+          "card": "Ardoz, Cobbler of War"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "UNLUCKY THIRTEEN",
+          "card": "Sling-Gang Lieutenant"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (1)",
+          "card": "Battle Cry Goblin"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (1)",
+          "card": "General Kreat, the Boltbringer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (1)",
+          "card": "Goblin Surprise"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (1)",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (2)",
+          "card": "Battle Cry Goblin"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (2)",
+          "card": "General Kreat, the Boltbringer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (2)",
+          "card": "Goblin Goliath"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (2)",
+          "card": "Goblin Surprise"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (2)",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (3)",
+          "card": "Beetleback Chief"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (3)",
+          "card": "General Kreat, the Boltbringer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (3)",
+          "card": "Goblin Surprise"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (3)",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (3)",
+          "card": "Krenko, Tin Street Kingpin"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (4)",
+          "card": "Battle Cry Goblin"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (4)",
+          "card": "General Kreat, the Boltbringer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Rabblemaster"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (4)",
+          "card": "Goblin Surprise"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GOBLINS (4)",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TOO MANY",
+          "card": "Goblin Surprise"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TOO MANY",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "BOROS LEGION 2",
+          "card": "Krenko's Command"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "GOBLINS",
+          "card": "Dragon Fodder"
+        }
+      ]
+    },
+    {
+      "name": "Goblin Wizard",
+      "type_line": "Token Creature — Goblin Wizard",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPELLINGCASTING (1)",
+          "card": "Goblin Wizardry"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "IZZET LEAGUE 2",
+          "card": "Goblin Wizardry"
+        }
+      ]
+    },
+    {
+      "name": "Griffin",
+      "type_line": "Token Creature — Griffin",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (1)",
+          "card": "Griffin Aerie"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (2)",
+          "card": "Griffin Aerie"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (3)",
+          "card": "Griffin Aerie"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (4)",
+          "card": "Griffin Aerie"
+        }
+      ]
+    },
+    {
+      "name": "Human",
+      "type_line": "Token Creature — Human",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ANGELS (1)",
+          "card": "Voice of the Provinces"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (1)",
+          "card": "Adeline, Resplendent Cathar"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (2)",
+          "card": "Adeline, Resplendent Cathar"
+        }
+      ]
+    },
+    {
+      "name": "Human Soldier",
+      "type_line": "Token Creature — Human Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (2)",
+          "card": "Ulvenwald Mysteries"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Ulvenwald Mysteries"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Bastion of Remembrance"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (1)",
+          "card": "Bastion of Remembrance"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "BOUNTY HUNTER (2)",
+          "card": "Bastion of Remembrance"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Quarrel's End"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Quarrel's End"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORTALS 1",
+          "card": "Faramir, Field Commander"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORTALS 2",
+          "card": "Faramir, Field Commander"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 1",
+          "card": "Quarrel's End"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 1",
+          "card": "Rally at the Hornburg"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 1",
+          "card": "Riders of the Mark"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 1",
+          "card": "Éomer of the Riddermark"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 2",
+          "card": "Rally at the Hornburg"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 2",
+          "card": "Riders of the Mark"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 2",
+          "card": "Éomer of the Riddermark"
+        }
+      ]
+    },
+    {
+      "name": "Incubator // Phyrexian",
+      "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
+      "colors": [],
+      "sources": [
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 1",
+          "card": "Essence of Orthodoxy"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 1",
+          "card": "Infected Defector"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 1",
+          "card": "Norn's Inquisitor"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 1",
+          "card": "Sunder the Gateway"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 1",
+          "card": "Tiller of Flesh"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 2",
+          "card": "Essence of Orthodoxy"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 2",
+          "card": "Infected Defector"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 2",
+          "card": "Norn's Inquisitor"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BROOD 2",
+          "card": "Tiller of Flesh"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BUFF 1",
+          "card": "Converter Beast"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BUFF 2",
+          "card": "Blighted Burgeoning"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "BUFF 2",
+          "card": "Converter Beast"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 1",
+          "card": "Gift of Compleation"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 1",
+          "card": "Injector Crocodile"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 2",
+          "card": "Compleated Huntmaster"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 2",
+          "card": "Gift of Compleation"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 2",
+          "card": "Injector Crocodile"
+        }
+      ]
+    },
+    {
+      "name": "Insect",
+      "type_line": "Token Creature — Insect",
+      "colors": [
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (1)",
+          "card": "Crawling Sensation"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (1)",
+          "card": "Iridescent Hornbeetle"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (1)",
+          "card": "Swarm Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (2)",
+          "card": "Crawling Sensation"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (3)",
+          "card": "Crawling Sensation"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (3)",
+          "card": "Iridescent Hornbeetle"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INSECTS (4)",
+          "card": "Crawling Sensation"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ICKY (1)",
+          "card": "Fumulus, the Infestation"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ICKY (2)",
+          "card": "Fumulus, the Infestation"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GOLGARI SWARM 1",
+          "card": "Amzu, Swarm's Hunger"
+        }
+      ]
+    },
+    {
+      "name": "Knight",
+      "type_line": "Token Creature — Knight",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "BASRI",
+          "card": "Basri's Lieutenant"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ENCHANTED (1)",
+          "card": "Knightly Valor"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ENCHANTED (2)",
+          "card": "Knightly Valor"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (1)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (2)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (3)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (4)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "UNICORNS",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (1)",
+          "card": "Gallant Cavalry"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (2)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BLINK (3)",
+          "card": "Valorous Steed"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "KNIGHTS",
+          "card": "The Circle of Loyalty"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (2)",
+          "card": "Basri's Lieutenant"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "OVERACHIEVER 2",
+          "card": "Xerex Strobe-Knight"
+        }
+      ]
+    },
+    {
+      "name": "Marit Lage",
+      "type_line": "Token Legendary Creature — Avatar",
+      "colors": [
+        "B"
+      ],
+      "power": "20",
+      "toughness": "20",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SNOW",
+          "card": "Marit Lage's Slumber"
+        }
+      ]
+    },
+    {
+      "name": "Merfolk",
+      "type_line": "Token Creature — Merfolk",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MERFOLK (1)",
+          "card": "Aquatic Incursion"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MERFOLK (4)",
+          "card": "Aquatic Incursion"
+        }
+      ]
+    },
+    {
+      "name": "Minotaur",
+      "type_line": "Token Creature — Minotaur",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINOTAURS (1)",
+          "card": "Flurry of Horns"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINOTAURS (1)",
+          "card": "Sethron, Hurloon General"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINOTAURS (2)",
+          "card": "Flurry of Horns"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINOTAURS (2)",
+          "card": "Sethron, Hurloon General"
+        }
+      ]
+    },
+    {
+      "name": "Monk",
+      "type_line": "Token Creature — Monk",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ROKU",
+          "card": "Crescent Island Temple"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SHRINES",
+          "card": "Crescent Island Temple"
+        }
+      ]
+    },
+    {
+      "name": "Orc Army",
+      "type_line": "Token Creature — Orc Army",
+      "colors": [
+        "B"
+      ],
+      "power": "0",
+      "toughness": "0",
+      "sources": [
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Assault on Osgiliath"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Foray of Orcs"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Grishnákh, Brash Instigator"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Swarming of Moria"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Assault on Osgiliath"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Foray of Orcs"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Grishnákh, Brash Instigator"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Swarming of Moria"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 1",
+          "card": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 1",
+          "card": "Mordor Muster"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Dunland Crebain"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Gríma Wormtongue"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Mordor Muster"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MORDOR 2",
+          "card": "Orcish Medicine"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Dunland Crebain"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Easterling Vanguard"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Mordor Muster"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Orcish Medicine"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Warg Rider"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Dunland Crebain"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Easterling Vanguard"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "March from the Black Gate"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Mordor Muster"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Warg Rider"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "RIDERS 2",
+          "card": "Book of Mazarbul"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "TRICKSY 2",
+          "card": "Saruman the White"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "TRICKSY 2",
+          "card": "Saruman's Trickery"
+        }
+      ]
+    },
+    {
+      "name": "Pegasus",
+      "type_line": "Token Creature — Pegasus",
+      "colors": [
+        "W"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CONSTELLATION (1)",
+          "card": "Archon of Sun's Grace"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ENCHANTED (4)",
+          "card": "Archon of Sun's Grace"
+        }
+      ]
+    },
+    {
+      "name": "Phyrexian Beast",
+      "type_line": "Token Creature — Phyrexian Beast",
+      "colors": [
+        "G"
+      ],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "TOXIC (1)",
+          "card": "Goliath Hatchery"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "TOXIC (2)",
+          "card": "Goliath Hatchery"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "TOXIC (2)",
+          "card": "Viral Spawning"
+        }
+      ]
+    },
+    {
+      "name": "Phyrexian Goblin",
+      "type_line": "Token Creature — Phyrexian Goblin",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (1)",
+          "card": "Chimney Rabble"
+        }
+      ]
+    },
+    {
+      "name": "Phyrexian Mite",
+      "type_line": "Token Artifact Creature — Phyrexian Mite",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "CORRUPTION (2)",
+          "card": "Stinging Hivemaster"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (1)",
+          "card": "Basilica Shepherd"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (1)",
+          "card": "Charge of the Mites"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (1)",
+          "card": "Infested Fleshcutter"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (1)",
+          "card": "Mite Overseer"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (2)",
+          "card": "Crawling Chorus"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "MITE-Y (2)",
+          "card": "Mite Overseer"
+        }
+      ]
+    },
+    {
+      "name": "Phyrexian Myr",
+      "type_line": "Token Artifact Creature — Phyrexian Myr",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PHYREXIAN",
+          "card": "Myr Sire"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PHYREXIAN",
+          "card": "Parasitic Implant"
+        }
+      ]
+    },
+    {
+      "name": "Pirate",
+      "type_line": "Token Creature — Pirate",
+      "colors": [
+        "R"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "UNDER THE SEA (1)",
+          "card": "Pursued Whale"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "UNDER THE SEA (2)",
+          "card": "Pursued Whale"
+        }
+      ]
+    },
+    {
+      "name": "Plant",
+      "type_line": "Token Creature — Plant",
+      "colors": [
+        "G"
+      ],
+      "power": "0",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LANDFALL (2)",
+          "card": "Avenger of Zendikar"
+        }
+      ]
+    },
+    {
+      "name": "Powerstone",
+      "type_line": "Token Artifact — Powerstone",
+      "colors": [],
+      "sources": [
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "INFANTRY (1)",
+          "card": "Static Net"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "INFANTRY (2)",
+          "card": "Static Net"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (1)",
+          "card": "Geology Enthusiast"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (1)",
+          "card": "Koilos Roc"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (1)",
+          "card": "Stern Lesson"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (1)",
+          "card": "Urza, Powerstone Prodigy"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (2)",
+          "card": "Geology Enthusiast"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (2)",
+          "card": "Koilos Roc"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (2)",
+          "card": "Stern Lesson"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (2)",
+          "card": "Urza, Powerstone Prodigy"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "TITANIC (1)",
+          "card": "Argothian Opportunist"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "WELDED (1)",
+          "card": "Horned Stoneseeker"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "WELDED (2)",
+          "card": "Excavation Explosion"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "WELDED (2)",
+          "card": "Horned Stoneseeker"
+        }
+      ]
+    },
+    {
+      "name": "Ragavan",
+      "type_line": "Token Legendary Creature — Monkey",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "RAID (1)",
+          "card": "Kari Zev, Skyship Raider"
+        }
+      ]
+    },
+    {
+      "name": "Rat",
+      "type_line": "Token Creature — Rat",
+      "colors": [
+        "B"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPOOKY (3)",
+          "card": "Ogre Slumlord"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "CYCLING (2)",
+          "card": "Mad Ratter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "RATS",
+          "card": "Ogre Slumlord"
+        }
+      ]
+    },
+    {
+      "name": "Rebel",
+      "type_line": "Token Creature — Rebel",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (1)",
+          "card": "Mirran Bardiche"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (2)",
+          "card": "Hexgold Hoverwings"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (2)",
+          "card": "Mirran Bardiche"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (3)",
+          "card": "Mirran Bardiche"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (4)",
+          "card": "Mirran Bardiche"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (1)",
+          "card": "Barbed Batterfist"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (1)",
+          "card": "Hexgold Halberd"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (1)",
+          "card": "Vulshok Splitter"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (2)",
+          "card": "Barbed Batterfist"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (2)",
+          "card": "Hexgold Halberd"
+        },
+        {
+          "set": "ONE",
+          "set_name": "Phyrexia: All Will Be One",
+          "deck": "REBELLIOUS (2)",
+          "card": "Vulshok Splitter"
+        }
+      ]
+    },
+    {
+      "name": "Saproling",
+      "type_line": "Token Creature — Saproling",
+      "colors": [
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LANDS (2)",
+          "card": "Sporemound"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (1)",
+          "card": "Fungal Rebirth"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (2)",
+          "card": "Fungal Rebirth"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (3)",
+          "card": "Fungal Rebirth"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PREDATORY (4)",
+          "card": "Fungal Rebirth"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "TREE-HUGGING (4)",
+          "card": "Verdant Embrace"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GROSS (2)",
+          "card": "Deathbloom Thallid"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GROSS (2)",
+          "card": "Fungal Infection"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINOSAURS (1)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINOSAURS (2)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ENCOUNTER (2)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ENCOUNTER (3)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Fungal Plots"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Saproling Migration"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Shroofus Sproutsire"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Spore Swarm"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (1)",
+          "card": "Tukatongue Thallid"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Fungal Plots"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Saproling Migration"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Shroofus Sproutsire"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Spore Swarm"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Undercellar Myconid"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "FUN GUYS (2)",
+          "card": "Verdeloth the Ancient"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LANDFALL (4)",
+          "card": "Sporemound"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "MODIFIED",
+          "card": "Saurian Symbiote"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "MONSTER TERRITORY",
+          "card": "The Weatherseed Treaty"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GOLGARI SWARM 1",
+          "card": "Tribune of Rot"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GOLGARI SWARM 2",
+          "card": "Fungal Rebirth"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GOLGARI SWARM 2",
+          "card": "Tribune of Rot"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Selesnya Guildmage"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Selesnya Guildmage"
+        }
+      ]
+    },
+    {
+      "name": "Snake",
+      "type_line": "Token Creature — Snake",
+      "colors": [
+        "B"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GROSS (4)",
+          "card": "Ophiomancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "SNAKES",
+          "card": "Aphelia, Viper Whisperer"
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Artifact Creature — Soldier",
+      "colors": [],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "INFANTRY (2)",
+          "card": "Scrapwork Cohort"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "WELDED (2)",
+          "card": "Mishra's Onslaught"
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "BASRI",
+          "card": "Basri Ket"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOCTOR (2)",
+          "card": "Secure the Scene"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOGS (1)",
+          "card": "Secure the Scene"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DOGS (2)",
+          "card": "Secure the Scene"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "HEAVILY ARMORED (1)",
+          "card": "Secure the Scene"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "HEAVILY ARMORED (2)",
+          "card": "Secure the Scene"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (1)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (2)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (3)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (4)",
+          "card": "Lena, Selfless Champion"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LEGION (4)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "RAINBOW",
+          "card": "Ironroot Warlord"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "HOLY (3)",
+          "card": "Dawn of Hope"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LAW (2)",
+          "card": "Decree of Justice"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "LAW (4)",
+          "card": "Murder Investigation"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (1)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (2)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (3)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ARMED (4)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (1)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (1)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (2)",
+          "card": "Ancestral Blade"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (2)",
+          "card": "Memorial to Glory"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (2)",
+          "card": "Raise the Alarm"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (1)",
+          "card": "Frontline Heroism"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (3)",
+          "card": "Akroan Crusader"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (3)",
+          "card": "Frontline Heroism"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STOKED (4)",
+          "card": "Akroan Crusader"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION CORPS",
+          "card": "Argivian Cavalier"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION CORPS",
+          "card": "Captain's Call"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION CORPS",
+          "card": "Resolute Reinforcements"
+        },
+        {
+          "set": "DMU",
+          "set_name": "Dominaria United",
+          "deck": "COALITION LEGION",
+          "card": "Argivian Cavalier"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Trostani Discordant"
+        }
+      ]
+    },
+    {
+      "name": "Soldier",
+      "type_line": "Token Creature — Soldier",
+      "colors": [
+        "R"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIRE NATION",
+          "card": "Fire Nation Attacks"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (1)",
+          "card": "Firebender Ascension"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "FIREBENDING (2)",
+          "card": "Fire Nation Attacks"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "REBELLING (1)",
+          "card": "Fire Nation Attacks"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (1)",
+          "card": "Fire Nation Occupation"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "RELENTLESS (2)",
+          "card": "Fire Nation Occupation"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ZUKO",
+          "card": "Fire Nation Attacks"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "BOROS LEGION 1",
+          "card": "Finale of Glory"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "FIREBENDING",
+          "card": "Fire Nation Archers"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "ZUKO TUTORIAL",
+          "card": "Zuko, Avatar Hunter"
+        }
+      ]
+    },
+    {
+      "name": "Spirit",
+      "type_line": "Token Creature — Spirit",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (1)",
+          "card": "Blessed Defiance"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (1)",
+          "card": "Doomed Traveler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (1)",
+          "card": "Mausoleum Guard"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (1)",
+          "card": "Not Forgotten"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (2)",
+          "card": "Blessed Defiance"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (2)",
+          "card": "Doomed Traveler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (2)",
+          "card": "Mausoleum Guard"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "SPIRITS (2)",
+          "card": "Triplicate Spirits"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "LEGION (2)",
+          "card": "Triplicate Spirits"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (1)",
+          "card": "Sandsteppe Outcast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (2)",
+          "card": "Sandsteppe Outcast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (3)",
+          "card": "Sandsteppe Outcast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (4)",
+          "card": "Sandsteppe Outcast"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "ADAPTIVE",
+          "card": "Lost in the Spirit World"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LIBRARIAN",
+          "card": "Lost in the Spirit World"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "LIBRARIAN",
+          "card": "Wan Shi Tong, All-Knowing"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SHRINES",
+          "card": "Hei Bai, Forest Guardian"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SPIRIT",
+          "card": "Baboon Spirit"
+        },
+        {
+          "set": "TLA",
+          "set_name": "Avatar: The Last Airbender",
+          "deck": "SPIRIT",
+          "card": "Lost in the Spirit World"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 1",
+          "card": "Afterlife Insurance"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 1",
+          "card": "Syndicate Messenger"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 2",
+          "card": "Afterlife Insurance"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 2",
+          "card": "Orzhov Racketeers"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 2",
+          "card": "Seraph of the Scales"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 1",
+          "card": "Doomed Traveler"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "SELESNYA CONCLAVE 2",
+          "card": "Transluminant"
+        },
+        {
+          "set": "TLB",
+          "set_name": "Avatar TLA Beginner Box",
+          "deck": "SPELLS",
+          "card": "Lost in the Spirit World"
+        }
+      ]
+    },
+    {
+      "name": "Tentacle",
+      "type_line": "Token Creature — Tentacle",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BOOKWORMS (4)",
+          "card": "Nadir Kraken"
+        }
+      ]
+    },
+    {
+      "name": "Thopter",
+      "type_line": "Token Artifact Creature — Thopter",
+      "colors": [
+        "U"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "ARCHAEOLOGY (3)",
+          "card": "Sharding Sphinx"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (1)",
+          "card": "Aviation Pioneer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (1)",
+          "card": "Launch Mishap"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (1)",
+          "card": "Tezzeret, Artifice Master"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (1)",
+          "card": "Whirler Rogue"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (2)",
+          "card": "Aviation Pioneer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (2)",
+          "card": "Hangarback Walker"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (2)",
+          "card": "Launch Mishap"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (2)",
+          "card": "Whirler Rogue"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (3)",
+          "card": "Aviation Pioneer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (3)",
+          "card": "Launch Mishap"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (3)",
+          "card": "Thopter Spy Network"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (3)",
+          "card": "Whirler Rogue"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (3)",
+          "card": "Whirlermaker"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (4)",
+          "card": "Aviation Pioneer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (4)",
+          "card": "Launch Mishap"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "INVENTIVE (4)",
+          "card": "Whirler Rogue"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BOOKWORMS (3)",
+          "card": "Thopter Mechanic"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (1)",
+          "card": "Experimental Aviator"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (1)",
+          "card": "Sai, Master Thopterist"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (1)",
+          "card": "Whirlermaker"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (2)",
+          "card": "Experimental Aviator"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (2)",
+          "card": "Sai, Master Thopterist"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (3)",
+          "card": "Experimental Aviator"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "INVENTIVE (4)",
+          "card": "Experimental Aviator"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "SOARING (3)",
+          "card": "Thopter Mechanic"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (1)",
+          "card": "Thopter Mechanic"
+        },
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "POWERSTONES (2)",
+          "card": "Thopter Mechanic"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "AZORIUS SENATE 2",
+          "card": "Depose"
+        }
+      ]
+    },
+    {
+      "name": "Treasure",
+      "type_line": "Token Artifact — Treasure",
+      "colors": [],
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (1)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (2)",
+          "card": "Gadrak, the Crown-Scourge"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DRAGONS (2)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (1)",
+          "card": "Corsair Captain"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (1)",
+          "card": "Prosperous Pirates"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (1)",
+          "card": "Sailor of Means"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (2)",
+          "card": "Corsair Captain"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (2)",
+          "card": "Prosperous Pirates"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "PIRATES (2)",
+          "card": "Sailor of Means"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Brazen Freebooter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Captain Lannery Storm"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Goldvein Pick"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Sudden Breakthrough"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (1)",
+          "card": "Trove of Temptation"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Brazen Freebooter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Goldvein Pick"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Improvised Weaponry"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Professional Face-Breaker"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (2)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Big Score"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Brazen Freebooter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Goldspan Dragon"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Goldvein Pick"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (3)",
+          "card": "Vault Robber"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Brazen Freebooter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Gadrak, the Crown-Scourge"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Gleaming Barrier"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Goldvein Pick"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Improvised Weaponry"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "TREASURE (4)",
+          "card": "Trove of Temptation"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "BLOODY (3)",
+          "card": "Scion of Opulence"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DINNER",
+          "card": "Tireless Provisioner"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (1)",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (1)",
+          "card": "Seize the Spoils"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "DRAGONS (2)",
+          "card": "Seize the Spoils"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (1)",
+          "card": "Tireless Provisioner"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (3)",
+          "card": "Deadly Dispute"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Deadly Dispute"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Shambling Ghast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GRAVE ROBBERS (2)",
+          "card": "Fake Your Own Death"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (1)",
+          "card": "Fake Your Own Death"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (1)",
+          "card": "Rev, Tithe Extractor"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (1)",
+          "card": "Thieves' Tools"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (2)",
+          "card": "Fake Your Own Death"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (2)",
+          "card": "Grim Bounty"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (2)",
+          "card": "Rev, Tithe Extractor"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NER-DO-WELLS (2)",
+          "card": "Thieves' Tools"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "NINJAS",
+          "card": "Prosperous Thief"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Deadly Dispute"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Dire Fleet Hoarder"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Fake Your Own Death"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Grim Bounty"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Pitiless Plunderer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Ruthless Knave"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Ruthless Technomancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Shambling Ghast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (1)",
+          "card": "Undercity Scrounger"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Contract Killing"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Deadly Dispute"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Dire Fleet Hoarder"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Fake Your Own Death"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Pitiless Plunderer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Ruthless Knave"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Shambling Ghast"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "TREASURES (2)",
+          "card": "Undercity Scrounger"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 1",
+          "card": "Deadly Derision"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "EXPENDABLE 2",
+          "card": "Deadly Derision"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 1",
+          "card": "Axgard Artisan"
+        },
+        {
+          "set": "MOM",
+          "set_name": "March of the Machine",
+          "deck": "REINFORCEMENT 2",
+          "card": "Axgard Artisan"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "CUNNING 2",
+          "card": "Bill Ferny, Bree Swindler"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 1",
+          "card": "Swarming of Moria"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "MARAUDERS 2",
+          "card": "Swarming of Moria"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 1",
+          "card": "Gorbag of Minas Morgul"
+        },
+        {
+          "set": "LTR",
+          "set_name": "The Lord of the Rings",
+          "deck": "ORCISH 2",
+          "card": "Gorbag of Minas Morgul"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "BOROS LEGION 2",
+          "card": "Shiny Impetus"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "CULT OF RAKDOS 1",
+          "card": "Deadly Dispute"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "GRUUL CLANS 1",
+          "card": "Shiny Impetus"
+        },
+        {
+          "set": "CLU",
+          "set_name": "Ravnica: Clue Edition",
+          "deck": "ORZHOV SYNDICATE 2",
+          "card": "Covetous Elegy"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "INFERNO",
+          "card": "Rapacious Dragon"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "INFERNO",
+          "card": "Seize the Spoils"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "PIRATES",
+          "card": "Corsair Captain"
+        }
+      ]
+    },
+    {
+      "name": "Vampire",
+      "type_line": "Token Creature — Vampire",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "STALWART (3)",
+          "card": "Paladin of the Bloodstained"
+        }
+      ]
+    },
+    {
+      "name": "Warrior",
+      "type_line": "Token Creature — Warrior",
+      "colors": [
+        "W"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ENCHANTED (2)",
+          "card": "Cartouche of Solidarity"
+        }
+      ]
+    },
+    {
+      "name": "Wizard",
+      "type_line": "Token Creature — Wizard",
+      "colors": [
+        "U"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GO TO SCHOOL (1)",
+          "card": "Kasmina, Enigmatic Mentor"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "GO TO SCHOOL (2)",
+          "card": "Kasmina, Enigmatic Mentor"
+        }
+      ]
+    },
+    {
+      "name": "Wolf",
+      "type_line": "Token Creature — Wolf",
+      "colors": [
+        "G"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Arlinn, Voice of the Pack"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Ferocious Pup"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Wolfkin Bond"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (1)",
+          "card": "Wolfwillow Haven"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (2)",
+          "card": "Arlinn, Voice of the Pack"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (2)",
+          "card": "Ferocious Pup"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (2)",
+          "card": "Master of the Wild Hunt"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Arlinn, Voice of the Pack"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Feed the Pack"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Ferocious Pup"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Kessig Cagebreakers"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Predator's Howl"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (3)",
+          "card": "Wolfwillow Haven"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (4)",
+          "card": "Arlinn, Voice of the Pack"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (4)",
+          "card": "Ferocious Pup"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (4)",
+          "card": "Nightpack Ambusher"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "WOLVES (4)",
+          "card": "Wolfwillow Haven"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "EXPLORERS (3)",
+          "card": "Somberwald Beastmaster"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "MODIFIED",
+          "card": "Wolfrider's Saddle"
+        }
+      ]
+    },
+    {
+      "name": "Worm",
+      "type_line": "Token Creature — Worm",
+      "colors": [
+        "B",
+        "G"
+      ],
+      "power": "1",
+      "toughness": "1",
+      "sources": [
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (3)",
+          "card": "Wriggling Grub"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ICKY (1)",
+          "card": "Wriggling Grub"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "ICKY (2)",
+          "card": "Wriggling Grub"
+        }
+      ]
+    },
+    {
+      "name": "Zombie",
+      "type_line": "Token Artifact Creature — Zombie",
+      "colors": [],
+      "power": "3",
+      "toughness": "3",
+      "sources": [
+        {
+          "set": "BRO",
+          "set_name": "The Brothers' War",
+          "deck": "UNEARTHED (2)",
+          "card": "Transmogrant Altar"
+        }
+      ]
+    },
+    {
+      "name": "Zombie",
+      "type_line": "Token Creature — Zombie",
+      "colors": [
+        "B"
+      ],
+      "power": "2",
+      "toughness": "2",
+      "sources": [
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "DISCARDING (2)",
+          "card": "Liliana's Reaver"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "LILIANA",
+          "card": "Liliana's Devotee"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (1)",
+          "card": "Ghoulcaller's Accomplice"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (2)",
+          "card": "Ghoulcaller's Accomplice"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (3)",
+          "card": "Ghoulcaller's Accomplice"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (3)",
+          "card": "Liliana's Devotee"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (4)",
+          "card": "Ghoulcaller Gisa"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (4)",
+          "card": "Ghoulcaller's Accomplice"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "MINIONS (4)",
+          "card": "Liliana's Devotee"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "REANIMATED (3)",
+          "card": "Zombie Infestation"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPOOKY (3)",
+          "card": "Liliana's Devotee"
+        },
+        {
+          "set": "JMP",
+          "set_name": "JumpStart 2020",
+          "deck": "SPOOKY (4)",
+          "card": "Liliana's Devotee"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BONEYARD (1)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "BONEYARD (2)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "DEMONS (2)",
+          "card": "Doomed Dissenter"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (1)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (1)",
+          "card": "Wakedancer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (2)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "MORBID (2)",
+          "card": "Wakedancer"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (1)",
+          "card": "Maalfeld Twins"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (1)",
+          "card": "Necromancer's Stockpile"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (1)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (2)",
+          "card": "Liliana, Death's Majesty"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (2)",
+          "card": "Maalfeld Twins"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (2)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (3)",
+          "card": "Endless Ranks of the Dead"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (3)",
+          "card": "Graf Harvest"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (3)",
+          "card": "Maalfeld Twins"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (3)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (4)",
+          "card": "Cellar Door"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (4)",
+          "card": "Liliana's Mastery"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (4)",
+          "card": "Maalfeld Twins"
+        },
+        {
+          "set": "J22",
+          "set_name": "JumpStart 2022",
+          "deck": "ZOMBIES (4)",
+          "card": "Suspicious Shambler"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (1)",
+          "card": "Doomed Dissenter"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (1)",
+          "card": "Moan of the Unhallowed"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (1)",
+          "card": "Wakedancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (2)",
+          "card": "Doomed Dissenter"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (2)",
+          "card": "Moan of the Unhallowed"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (3)",
+          "card": "Boneclad Necromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Army of the Damned"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Doomed Dissenter"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Moan of the Unhallowed"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GHASTLY (4)",
+          "card": "Wakedancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GRAVE ROBBERS (3)",
+          "card": "Boneclad Necromancer"
+        },
+        {
+          "set": "J25",
+          "set_name": "JumpStart Foundations",
+          "deck": "GRAVE ROBBERS (4)",
+          "card": "Liliana, Death's Majesty"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "UNDEAD",
+          "card": "Maalfeld Twins"
+        },
+        {
+          "set": "FDN",
+          "set_name": "Foundations Beginner Box",
+          "deck": "UNDEAD",
+          "card": "Suspicious Shambler"
+        }
+      ]
+    }
+  ]
+}

--- a/etc/parsing-scripts/README.md
+++ b/etc/parsing-scripts/README.md
@@ -62,6 +62,176 @@ DECK NAME
 2 Plains
 ```
 
+## JSON & Token Data Pipeline
+
+After the `.txt` deck lists are formatted, run these scripts to generate structured JSON files and a consolidated token reference.
+
+### Full Pipeline (run in order)
+
+```bash
+cd etc/parsing-scripts
+
+# 1. Backfill token data for any cards missing it in the cache
+python add_token_data.py
+
+# 2. Backfill keywords/oracle_id for tokens that were cached before those fields existed
+python update_token_keywords.py
+
+# 3. Generate individual deck JSON files from the .txt files + cache
+python generate_json_decks.py ../JMP/ ../J22/ ../J25/ ../TLA/ ../ONE/ ../DMU/ ../BRO/ ../MOM/ ../LTR/ ../CLU/ ../FDN/ ../TLB/
+
+# 4. Generate the master combined JSON (all decks + card index)
+python generate_combined_json.py
+
+# 5. Generate the consolidated token index
+python generate_token_index.py
+```
+
+**When to re-run:** Any time you update the card cache (new set, new token backfill), re-run steps 3–5. If token data or keywords changed in the cache, re-run all 5 steps.
+
+### `generate_token_index.py`
+Scans all deck JSON files and builds a consolidated token reference.
+
+**Usage:**
+```bash
+python generate_token_index.py
+```
+
+No arguments needed. Output is written to `etc/jumpstart-token-index.json`.
+
+**What it does:**
+- Reads every `tokens` array from every card in every deck JSON across all 12 sets
+- Deduplicates tokens by `oracle_id` (fallback: `name + type_line + power/toughness`)
+- Records which set, deck, and card produces each token
+- Sorts tokens alphabetically; sources sorted by set order, then deck, then card
+
+**Output structure:**
+```json
+{
+  "metadata": { "total_tokens": 101, "total_source_refs": 921, ... },
+  "tokens": [
+    {
+      "name": "Angel",
+      "type_line": "Token Creature — Angel",
+      "colors": ["W"],
+      "power": "4",
+      "toughness": "4",
+      "keywords": ["Flying"],
+      "oracle_id": "...",
+      "sources": [
+        { "set": "JMP", "set_name": "JumpStart 2020", "deck": "ANGELS (1)", "card": "Serra Angel" },
+        ...
+      ]
+    }
+  ]
+}
+```
+
+### `generate_json_decks.py`
+Generates individual `{deck}.json` files from each `{deck}.txt` using card data from the cache.
+
+**Usage:**
+```bash
+python generate_json_decks.py <set_dir>... [--dry-run]
+```
+
+**Examples:**
+```bash
+# Single set
+python generate_json_decks.py ../TLA/
+
+# All sets at once
+python generate_json_decks.py ../JMP/ ../J22/ ../J25/ ../TLA/ ../ONE/ ../DMU/ ../BRO/ ../MOM/ ../LTR/ ../CLU/ ../FDN/ ../TLB/
+
+# Preview without writing
+python generate_json_decks.py ../J25/ --dry-run
+```
+
+Each output JSON includes `deck_name`, `set`, a top-level `tokens` array (deduplicated), and a `cards` array with full card data (type, mana cost, colors, P/T, tokens produced, etc.).
+
+### `generate_combined_json.py`
+Generates `etc/jumpstart-decks-combined.json` — a single file with all decks and a card → deck index.
+
+**Usage:**
+```bash
+python generate_combined_json.py
+```
+
+No arguments. Reads all deck JSONs from all 12 set directories and writes the combined file.
+
+### `add_token_data.py`
+Backfills token data into `card_type_cache.json` for cards that don't yet have a `tokens` key.
+
+**Usage:**
+```bash
+python add_token_data.py [options]
+
+Options:
+  --delay MS    Milliseconds between Scryfall API calls (default: 250)
+  --dry-run     Show what would change without writing
+  --limit N     Only process first N uncached cards (for testing)
+  --verbose     Print every card, not just those with tokens
+```
+
+Cards with `skip_reason` in the cache (placeholders, parse artifacts) are skipped automatically.
+
+### `update_token_keywords.py`
+Backfills `keywords` and `oracle_id` into token objects for cards that were cached before those fields were added.
+
+**Usage:**
+```bash
+python update_token_keywords.py [options]
+
+Options:
+  --delay MS    Milliseconds between Scryfall API calls (default: 250)
+  --dry-run     Show what would change without writing
+  --limit N     Only process first N cards (for testing)
+  --verbose     Print every card processed
+```
+
+Safe to re-run — skips cards whose tokens already have `keywords`.
+
+### Starting from Scratch / Repopulating the Cache
+
+If `card_type_cache.json` is lost or you need to rebuild it from the existing `.txt` deck lists:
+
+```bash
+cd etc/parsing-scripts
+
+# 1. Format all sets — this queries Scryfall for every unique card and rebuilds the cache
+#    (~2,500 unique cards; at 250ms/call expect ~10-15 min)
+python batch_reformat.py \
+  ../JMP/ ../J22/ ../J25/ ../TLA/ \
+  ../ONE/ ../DMU/ ../BRO/ ../MOM/ \
+  ../LTR/ ../CLU/ ../FDN/ ../TLB/ \
+  --load-cache --save-cache
+
+# 2. Backfill token data (which cards produce which tokens)
+python add_token_data.py
+
+# 3. Backfill keywords and oracle_id into token objects
+python update_token_keywords.py
+
+# 4. Regenerate all deck JSON files
+python generate_json_decks.py \
+  ../JMP/ ../J22/ ../J25/ ../TLA/ \
+  ../ONE/ ../DMU/ ../BRO/ ../MOM/ \
+  ../LTR/ ../CLU/ ../FDN/ ../TLB/
+
+# 5. Regenerate combined JSON
+python generate_combined_json.py
+
+# 6. Regenerate token index
+python generate_token_index.py
+```
+
+**Tips:**
+- `batch_reformat.py` uses `--load-cache` + `--save-cache` together so it picks up any partial cache and saves incrementally as it goes.
+- `add_token_data.py` and `update_token_keywords.py` both save every 25 cards, so interrupted runs can be safely resumed.
+- The `--delay` flag on all API scripts defaults to 250ms. Lower it (`--delay 100`) if Scryfall is responsive; raise it (`--delay 500`) if you're seeing errors.
+
+---
+
 ## Core Scripts (Essential)
 
 ### `compare_variants.py` — Spreadsheet Checklists

--- a/etc/parsing-scripts/add_token_data.py
+++ b/etc/parsing-scripts/add_token_data.py
@@ -73,6 +73,9 @@ def fetch_token_details(token_uri: str) -> Dict:
             details["power"] = data["power"]
         if data.get("toughness") is not None:
             details["toughness"] = data["toughness"]
+        details["keywords"] = data.get("keywords", [])
+        if data.get("oracle_id"):
+            details["oracle_id"] = data["oracle_id"]
 
         token_detail_cache[token_uri] = details
         return details

--- a/etc/parsing-scripts/batch_reformat.py
+++ b/etc/parsing-scripts/batch_reformat.py
@@ -255,6 +255,9 @@ def fetch_token_details(token_uri: str) -> Dict:
             details["power"] = data["power"]
         if data.get("toughness") is not None:
             details["toughness"] = data["toughness"]
+        details["keywords"] = data.get("keywords", [])
+        if data.get("oracle_id"):
+            details["oracle_id"] = data["oracle_id"]
 
         token_detail_cache[token_uri] = details
         return details

--- a/etc/parsing-scripts/card_type_cache.json
+++ b/etc/parsing-scripts/card_type_cache.json
@@ -70,7 +70,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -234,7 +236,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
       }
     ]
   },
@@ -409,7 +413,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
       }
     ]
   },
@@ -480,7 +488,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
       }
     ]
   },
@@ -684,7 +696,9 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "6788478d-e157-4483-be09-9edb3f841431"
       }
     ]
   },
@@ -719,7 +733,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
       }
     ]
   },
@@ -741,7 +759,9 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "9fcff433-c6f7-44c6-8279-04625703cb3e"
       }
     ]
   },
@@ -764,7 +784,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
       }
     ]
   },
@@ -839,7 +861,11 @@
           "U"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
       }
     ]
   },
@@ -893,7 +919,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -977,7 +1005,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -1041,7 +1071,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "ea029c48-d26e-40b1-acef-2ec47fb61101"
       }
     ]
   },
@@ -1086,7 +1118,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -1242,7 +1276,11 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
       }
     ]
   },
@@ -1424,7 +1462,11 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Deathtouch"
+        ],
+        "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
       }
     ]
   },
@@ -1497,7 +1539,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Hexproof"
+        ],
+        "oracle_id": "fd6663bc-49ae-4e31-b0aa-60f142dfd18c"
       }
     ]
   },
@@ -1597,7 +1643,11 @@
           "B"
         ],
         "power": "5",
-        "toughness": "5"
+        "toughness": "5",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
       }
     ]
   },
@@ -1659,7 +1709,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "246d7a00-288d-448e-9b77-8af41e40a44d"
       }
     ]
   },
@@ -1682,7 +1736,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -1718,7 +1774,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -1750,7 +1808,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -1785,7 +1845,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -1845,7 +1907,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -2002,7 +2066,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -2060,7 +2126,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
       }
     ]
   },
@@ -2249,7 +2317,9 @@
           "G"
         ],
         "power": "0",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "bcd346a7-4d96-4a0c-9725-fb740e32b730"
       }
     ]
   },
@@ -2285,7 +2355,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -2317,7 +2391,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -2413,7 +2489,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -2460,7 +2538,9 @@
         "type_line": "Token Creature — Spirit",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
       }
     ]
   },
@@ -2499,7 +2579,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -2668,7 +2750,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
       }
     ]
   },
@@ -2768,7 +2852,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -2790,7 +2878,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -2826,7 +2916,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
       }
     ]
   },
@@ -2858,7 +2952,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -2892,7 +2988,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -3067,7 +3165,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -3097,7 +3197,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -3236,7 +3338,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -3281,7 +3385,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -3300,7 +3406,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -3510,7 +3618,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -3577,7 +3689,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -3627,7 +3743,9 @@
         "type_line": "Token Creature — Eldrazi Scion",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
       }
     ]
   },
@@ -3729,7 +3847,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -3774,7 +3894,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -4159,7 +4281,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -4193,7 +4317,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -4290,7 +4416,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -4379,7 +4507,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -4435,7 +4565,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -4493,7 +4625,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -4555,7 +4689,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "53c009a1-b9b6-43d6-8543-77688fedf8ae"
       }
     ]
   },
@@ -4578,7 +4716,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "e4a19155-6689-43de-8175-f28dd2cf0a9a"
       }
     ]
   },
@@ -4667,7 +4807,9 @@
         "type_line": "Token Creature — Eldrazi Scion",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
       }
     ]
   },
@@ -4778,7 +4920,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -4917,7 +5061,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -4934,7 +5080,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -4990,7 +5138,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -5070,7 +5220,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -5102,7 +5254,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -5136,7 +5290,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -5180,7 +5336,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -5236,7 +5394,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "4bd91cb2-be86-4950-8b84-7b330a8a61b9"
       }
     ]
   },
@@ -5476,7 +5638,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -5713,7 +5877,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -5845,7 +6013,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "b43340e3-bb76-4501-8db2-040b7cae33b7"
       }
     ]
   },
@@ -5980,7 +6150,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -6210,7 +6382,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -6378,7 +6552,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -6409,7 +6587,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -6520,7 +6700,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -6539,7 +6721,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -6594,7 +6780,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -6674,7 +6862,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -6760,7 +6950,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -6884,7 +7076,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -6905,7 +7101,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
       }
     ]
   },
@@ -6948,7 +7146,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -6969,7 +7169,11 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Prowess"
+        ],
+        "oracle_id": "026e1dbb-bbe4-4164-af19-262a85f4a69d"
       }
     ]
   },
@@ -7184,7 +7388,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -7361,7 +7567,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
       }
     ]
   },
@@ -7476,7 +7684,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
       }
     ]
   },
@@ -7620,7 +7832,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -7637,7 +7851,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -7752,7 +7968,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -7797,7 +8015,11 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
       },
       {
         "name": "Soldier",
@@ -7806,7 +8028,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -8012,7 +8236,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -8284,7 +8512,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -8498,7 +8728,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -8534,7 +8766,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -8621,7 +8857,11 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "ec6df381-5ea7-4c68-8416-093b107f0784"
       }
     ]
   },
@@ -8642,7 +8882,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -9010,7 +9252,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -9146,7 +9390,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -9242,7 +9488,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -9265,7 +9513,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -9439,7 +9689,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -9458,7 +9710,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -9574,7 +9828,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -9610,7 +9866,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -9675,7 +9933,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -9770,7 +10030,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -9858,7 +10120,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -9942,7 +10206,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -10139,7 +10405,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -10269,7 +10537,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -10380,7 +10652,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -10512,7 +10786,9 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "5bef2c1c-7215-4b01-8bb3-426e1c3dd2e0"
       }
     ]
   },
@@ -10544,7 +10820,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -10692,7 +10972,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
       }
     ]
   },
@@ -10783,7 +11067,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -10806,7 +11092,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
       }
     ]
   },
@@ -10825,7 +11115,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -10948,7 +11240,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -11087,7 +11381,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -11132,7 +11428,9 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "8050907b-4007-4478-8ebd-25b8b2bf85c3"
       }
     ]
   },
@@ -11268,7 +11566,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -11372,7 +11672,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -11472,7 +11774,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "01e023e5-38bc-4203-aecb-6b2de54b03ea"
       },
       {
         "name": "Angel",
@@ -11481,7 +11787,12 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying",
+          "Vigilance"
+        ],
+        "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
       }
     ]
   },
@@ -11554,7 +11865,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
       }
     ]
   },
@@ -11575,7 +11888,11 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Firebending"
+        ],
+        "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
       }
     ]
   },
@@ -11622,7 +11939,11 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Firebending"
+        ],
+        "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
       }
     ]
   },
@@ -11641,7 +11962,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -11695,7 +12018,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -11727,7 +12052,11 @@
         "type_line": "Token Artifact Creature — Construct",
         "colors": [],
         "power": "2",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
       }
     ]
   },
@@ -11785,7 +12114,11 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Firebending"
+        ],
+        "oracle_id": "768c67a6-a6d0-4001-a252-72ae24b2829e"
       }
     ]
   },
@@ -12103,7 +12436,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -12187,7 +12522,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
       }
     ]
   },
@@ -12296,7 +12633,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -12337,7 +12676,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -12418,7 +12759,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -12439,7 +12782,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -12597,7 +12942,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "971191ac-dedb-4cba-842e-65339a25ce44"
       }
     ]
   },
@@ -12684,7 +13031,11 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
       }
     ]
   },
@@ -12716,7 +13067,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -12737,7 +13090,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -12758,7 +13113,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -12891,7 +13248,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -12986,7 +13345,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
       }
     ]
   },
@@ -13094,7 +13457,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
       }
     ]
   },
@@ -13180,7 +13545,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -13212,7 +13579,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -13294,7 +13663,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -13317,7 +13688,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -13362,7 +13735,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -13385,7 +13760,11 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "5e34ad53-c154-4302-b25a-fe4bb1555a5f"
       }
     ]
   },
@@ -13456,12 +13835,16 @@
           "G"
         ],
         "power": "7",
-        "toughness": "7"
+        "toughness": "7",
+        "keywords": [],
+        "oracle_id": "33ec3894-6ec2-4038-bed4-85e5b9cfe182"
       },
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -13529,7 +13912,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -13712,7 +14099,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -13881,7 +14270,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -14089,7 +14480,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -14136,7 +14529,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -14207,7 +14602,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -14228,7 +14625,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -14288,7 +14687,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -14335,7 +14736,11 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Prowess"
+        ],
+        "oracle_id": "4d7a06f9-2569-4b72-bd5f-5a190337a692"
       }
     ]
   },
@@ -14415,7 +14820,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -14430,7 +14837,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -14503,7 +14912,11 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
       }
     ]
   },
@@ -14572,7 +14985,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -14669,7 +15084,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -14690,7 +15107,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -14852,7 +15271,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "3d395892-ef4e-41ea-a66b-99dc3affe51a"
       }
     ]
   },
@@ -14882,7 +15305,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -14918,7 +15343,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -15038,7 +15465,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -15190,7 +15619,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -15412,7 +15845,9 @@
         "type_line": "Token Creature — Spirit",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
       }
     ]
   },
@@ -15629,7 +16064,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
       }
     ]
   },
@@ -15650,7 +16087,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
       }
     ]
   },
@@ -15803,7 +16242,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -15873,7 +16314,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -15907,7 +16350,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -15926,7 +16371,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -16109,7 +16556,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -16171,7 +16620,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -16386,7 +16837,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -16403,7 +16856,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -16472,7 +16927,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
       }
     ]
   },
@@ -16515,7 +16972,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -16600,7 +17061,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -16674,7 +17139,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -16899,7 +17368,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -17001,7 +17472,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
       }
     ]
   },
@@ -17084,7 +17557,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -17232,7 +17707,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -17302,7 +17779,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -17476,7 +17955,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "2069c2cb-3cb7-4f3b-be72-ae783de82c42"
       }
     ]
   },
@@ -17495,7 +17976,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -17569,7 +18052,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -17716,7 +18201,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "e2a98673-a9c2-4579-b962-080405bbb661"
       }
     ]
   },
@@ -17761,7 +18248,9 @@
           "U"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "3e211a1b-7115-422b-bcb5-3d6c005afd7f"
       }
     ]
   },
@@ -17928,7 +18417,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -17971,7 +18462,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -18077,7 +18570,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -18185,7 +18680,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
       }
     ]
   },
@@ -18217,7 +18716,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -18275,7 +18776,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -18400,7 +18903,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -18423,7 +18928,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -18446,7 +18953,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -18556,7 +19065,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -18616,7 +19127,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -18698,7 +19211,11 @@
           "R"
         ],
         "power": "5",
-        "toughness": "5"
+        "toughness": "5",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
       }
     ]
   },
@@ -18730,7 +19247,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -18801,7 +19322,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -18928,7 +19451,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -18951,7 +19476,11 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "ff86d8fc-5242-405e-b5e3-f9ff73296794"
       }
     ]
   },
@@ -18994,7 +19523,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -19065,7 +19596,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
       }
     ]
   },
@@ -19302,7 +19837,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -19336,7 +19873,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -19359,7 +19898,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -19407,7 +19948,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -19649,7 +20192,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -19703,7 +20248,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -19733,7 +20280,9 @@
         "type_line": "Token Creature — Spirit",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
       }
     ]
   },
@@ -19791,7 +20340,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
       }
     ]
   },
@@ -19823,7 +20376,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -19896,7 +20451,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -19930,7 +20487,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -19975,7 +20534,9 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
       }
     ]
   },
@@ -20066,7 +20627,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -20260,7 +20823,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -20329,7 +20894,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -20363,7 +20930,12 @@
           "B"
         ],
         "power": "20",
-        "toughness": "20"
+        "toughness": "20",
+        "keywords": [
+          "Flying",
+          "Indestructible"
+        ],
+        "oracle_id": "48e9147e-59f7-4693-83d7-7f514be871bc"
       }
     ]
   },
@@ -20406,7 +20978,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -20556,7 +21130,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -20599,7 +21175,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -20633,7 +21211,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -20683,7 +21265,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -20744,7 +21328,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -20855,7 +21441,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -20925,7 +21513,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -21245,7 +21835,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
       }
     ]
   },
@@ -21325,7 +21917,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
       }
     ]
   },
@@ -21364,7 +21960,9 @@
         "type_line": "Token Artifact Creature — Soldier",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
       }
     ]
   },
@@ -21433,7 +22031,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -21452,7 +22054,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -21473,7 +22077,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -21751,7 +22357,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -21772,7 +22380,11 @@
         "type_line": "Token Artifact Creature — Construct",
         "colors": [],
         "power": "2",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "ba138dd6-6eab-4f97-92b0-ca47d0042216"
       }
     ]
   },
@@ -21886,7 +22498,11 @@
           "U"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "28cd830b-def6-4aa3-a0f6-6913bcdf931e"
       }
     ]
   },
@@ -21932,7 +22548,9 @@
           "U"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [],
+        "oracle_id": "f81c047d-de36-4aed-806b-f14a290771a4"
       }
     ]
   },
@@ -21977,7 +22595,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -22000,7 +22620,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "6c29dcc1-d7b6-4ef6-b663-0cc0e4be0529"
       }
     ]
   },
@@ -22080,7 +22704,9 @@
         "type_line": "Token Artifact Creature — Phyrexian Myr",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2"
       }
     ]
   },
@@ -22147,7 +22773,9 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "82adaeee-e011-49db-af53-fda6c2b192d5"
       }
     ]
   },
@@ -22303,7 +22931,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -22522,7 +23152,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -22704,7 +23336,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -22736,7 +23372,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -22755,7 +23395,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -22800,7 +23442,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -22903,7 +23547,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -22987,7 +23633,9 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "7c753b68-b519-43ba-9c58-4902f4850626"
       }
     ]
   },
@@ -23121,7 +23769,11 @@
           "B"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Deathtouch"
+        ],
+        "oracle_id": "c02feaa1-8540-4948-b92f-01a719218c2b"
       }
     ]
   },
@@ -23214,7 +23866,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -23235,7 +23889,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -23390,7 +24046,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -23446,7 +24104,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
       }
     ]
   },
@@ -23777,7 +24439,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "97af46cb-6209-4ae7-81cc-792894999937"
       }
     ]
   },
@@ -23829,7 +24495,9 @@
         "type_line": "Token Artifact Creature — Phyrexian Myr",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "53ccb03f-a853-4df9-8c00-39279d15f3b2"
       }
     ]
   },
@@ -23909,7 +24577,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -23991,7 +24661,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "b1612d71-4e81-4ea7-95d9-05ed7a70e5f1"
       }
     ]
   },
@@ -24010,7 +24682,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -24598,7 +25272,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -24883,7 +25559,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -24929,7 +25607,9 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
       }
     ]
   },
@@ -24974,7 +25654,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -24991,7 +25673,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -25010,7 +25694,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -25034,7 +25720,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -25092,7 +25780,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "5ae6251d-cef9-4fb7-bdcd-e870a062f042"
       }
     ]
   },
@@ -25154,7 +25844,11 @@
           "B"
         ],
         "power": "5",
-        "toughness": "5"
+        "toughness": "5",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
       }
     ]
   },
@@ -25186,7 +25880,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
       }
     ]
   },
@@ -25268,7 +25964,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -25310,7 +26008,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -25329,7 +26029,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -25448,7 +26150,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "f24f68d0-6e81-4294-a084-8ec8f36fef18"
       }
     ]
   },
@@ -25545,7 +26249,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -25753,7 +26459,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -25854,7 +26562,9 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "e1cab9f5-a094-4df4-9094-71bebf91956f"
       }
     ]
   },
@@ -25875,7 +26585,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -25944,7 +26656,9 @@
           "G"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [],
+        "oracle_id": "695b14a0-920a-47bd-bd4a-7989862cdd0a"
       }
     ]
   },
@@ -26067,7 +26781,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -26088,7 +26804,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "8653c69b-99a9-4881-a14c-68ba928c34d5"
       }
     ]
   },
@@ -26138,7 +26856,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -26523,7 +27243,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "65742c00-2809-4085-a950-8f93845c03d2"
       }
     ]
   },
@@ -26544,7 +27268,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "791a992f-6f67-41a0-8100-a4a6401e6148"
       }
     ]
   },
@@ -26755,7 +27481,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -26775,7 +27503,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -26831,7 +27561,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -26872,7 +27604,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -26989,7 +27723,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -27058,7 +27794,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -27359,7 +28097,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -27619,7 +28359,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -27649,7 +28391,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -27746,7 +28490,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -27765,7 +28513,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -27875,7 +28625,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -27903,7 +28657,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -27961,7 +28717,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -28044,7 +28802,11 @@
           "R"
         ],
         "power": "5",
-        "toughness": "5"
+        "toughness": "5",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "60fe4897-6760-4c5a-8074-c92bd64df52b"
       }
     ]
   },
@@ -28079,7 +28841,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -28100,7 +28864,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -28136,7 +28902,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -28286,7 +29054,9 @@
         "type_line": "Token Creature — Eldrazi Scion",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "0eb3cd4b-c34e-448c-a9ab-e7b0b4524833"
       }
     ]
   },
@@ -28318,7 +29088,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -28400,7 +29172,9 @@
         "type_line": "Token Artifact Creature — Soldier",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "0410f6f6-88f6-48e2-b301-7660c86317a1"
       }
     ]
   },
@@ -28605,7 +29379,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -28635,7 +29411,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "eac25f12-6459-438c-a09e-93e23d2cf80d"
       }
     ]
   },
@@ -28715,7 +29493,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -28736,7 +29516,11 @@
           "R"
         ],
         "power": "*",
-        "toughness": "*"
+        "toughness": "*",
+        "keywords": [
+          "Trample"
+        ],
+        "oracle_id": "74a3dea1-6a43-4cd2-925e-0abcf076bd02"
       }
     ]
   },
@@ -28769,7 +29553,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -28860,7 +29646,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "b1a2b096-a440-4ef9-ab2a-059c79999297"
       }
     ]
   },
@@ -28937,7 +29727,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
       }
     ]
   },
@@ -29119,7 +29913,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6b8117bf-384f-4f5e-9e52-e01412ce24a9"
       }
     ]
   },
@@ -29197,7 +29993,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -29270,7 +30068,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "e3c8482e-ce21-43f8-ac07-c26c01941a4d"
       }
     ]
   },
@@ -29320,7 +30122,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -29396,7 +30200,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -29546,7 +30352,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -29580,7 +30388,11 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
       }
     ]
   },
@@ -29795,7 +30607,11 @@
           "B"
         ],
         "power": "5",
-        "toughness": "5"
+        "toughness": "5",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "0045c5fa-3229-4050-b139-5712fa24b308"
       }
     ]
   },
@@ -30042,7 +30858,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "4465eff4-5851-4721-a248-866c686c2ab8"
       }
     ]
   },
@@ -30246,7 +31064,11 @@
           "R"
         ],
         "power": "3",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Haste"
+        ],
+        "oracle_id": "74658c70-caa8-4172-8a65-055d327668f9"
       }
     ]
   },
@@ -30274,7 +31096,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -30331,7 +31155,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -30389,7 +31215,9 @@
           "G"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [],
+        "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
       },
       {
         "name": "Beast",
@@ -30398,7 +31226,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
       },
       {
         "name": "Wolf",
@@ -30407,7 +31237,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -30635,7 +31467,11 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
       }
     ]
   },
@@ -30821,7 +31657,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -30870,7 +31708,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -30966,7 +31806,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "11734409-b03b-4905-af83-261f29a96bc2"
       }
     ]
   },
@@ -31100,7 +31942,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -31231,7 +32075,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -31248,7 +32094,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -31269,7 +32117,11 @@
         "type_line": "Token Artifact Creature — Phyrexian Mite",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "2667d723-01c8-4ea3-ac17-cedb3b842c3b"
       }
     ]
   },
@@ -31364,7 +32216,11 @@
           "U"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "03fc0cae-a6d3-4fae-995d-038eb32c48ac"
       }
     ]
   },
@@ -31579,7 +32435,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -31613,7 +32471,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -31650,7 +32510,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -31670,7 +32532,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -31713,7 +32577,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -31882,7 +32750,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -31986,7 +32856,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "c39cd31f-c4a2-4ca8-b4f9-b2e6289743bc"
       }
     ]
   },
@@ -32016,7 +32888,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       },
       {
         "name": "Orc Army",
@@ -32025,7 +32899,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -32141,7 +33017,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -32165,7 +33043,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "18ef473d-f958-4bff-8045-154f6adc6b04"
       }
     ]
   },
@@ -32365,7 +33247,11 @@
           "U"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
       }
     ]
   },
@@ -32388,7 +33274,11 @@
           "U"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "9e266374-80f1-458a-9417-16220d2a013a"
       }
     ]
   },
@@ -32414,7 +33304,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -32615,7 +33507,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -32805,7 +33699,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -32844,7 +33742,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -32909,7 +33809,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -32930,7 +33832,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -32951,7 +33855,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
       }
     ]
   },
@@ -32996,7 +33904,9 @@
           "G"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [],
+        "oracle_id": "af4bd34a-0a0b-4c53-8f13-579c45ab471a"
       }
     ]
   },
@@ -33044,7 +33954,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -33098,7 +34010,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -33155,7 +34069,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -33226,7 +34142,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -33245,7 +34165,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -33323,7 +34247,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -33346,7 +34272,9 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "6bb61f34-5d57-4eaa-a02c-f5d08c1ee920"
       }
     ]
   },
@@ -33516,7 +34444,11 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [
+          "Trample"
+        ],
+        "oracle_id": "240300bd-5088-43c5-a873-290507515843"
       }
     ]
   },
@@ -33535,7 +34467,9 @@
       {
         "name": "Copy",
         "type_line": "Token",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "88c78601-87f0-45e7-b2e0-e7ffcfb1cb70"
       }
     ]
   },
@@ -33632,7 +34566,11 @@
       {
         "name": "Incubator // Phyrexian",
         "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian",
-        "colors": []
+        "colors": [],
+        "keywords": [
+          "Transform"
+        ],
+        "oracle_id": "dd3bf75e-9ef0-4ded-9b65-1a60a78a6253"
       }
     ]
   },
@@ -33688,12 +34626,16 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       },
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -33712,7 +34654,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -33790,7 +34734,11 @@
           "B"
         ],
         "power": "*",
-        "toughness": "*"
+        "toughness": "*",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "0f6d78a4-f330-47b5-9c30-51324a1e7fb9"
       }
     ]
   },
@@ -34000,7 +34948,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -34091,7 +35041,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -34164,7 +35116,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -34181,7 +35137,9 @@
         "type_line": "Token Artifact Creature — Zombie",
         "colors": [],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [],
+        "oracle_id": "82868a85-a6f4-47db-b159-d23a9c4c9892"
       }
     ]
   },
@@ -34241,7 +35199,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "63d59a37-fd7c-4d53-a666-7db6fae2f78f"
       }
     ]
   },
@@ -34296,7 +35256,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -34317,7 +35279,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c"
       }
     ]
   },
@@ -34365,7 +35331,11 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Lifelink"
+        ],
+        "oracle_id": "a5ab7f2d-a434-4342-a178-754bdd0181b6"
       }
     ]
   },
@@ -34395,7 +35365,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -34412,7 +35384,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -34509,7 +35483,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -34717,7 +35693,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -34795,7 +35773,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       },
       {
         "name": "Human Soldier",
@@ -34804,7 +35784,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },
@@ -34909,7 +35891,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -34928,7 +35912,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -35054,7 +36040,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -35166,7 +36154,11 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "40c64f08-ab2f-4933-8e0e-d1a1c729008f"
       }
     ]
   },
@@ -35220,7 +36212,9 @@
         "type_line": "Token Artifact Creature — Assembly-Worker",
         "colors": [],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "02e1a471-36b2-4d28-a323-f4ec3d095cb9"
       }
     ]
   },
@@ -35277,7 +36271,9 @@
       {
         "name": "Powerstone",
         "type_line": "Token Artifact — Powerstone",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "91da73fe-d028-43d7-bf75-f7ef30b45664"
       }
     ]
   },
@@ -35313,7 +36309,12 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying",
+          "Vigilance"
+        ],
+        "oracle_id": "29ff8699-53d8-413b-8a3c-0e3ea1e13ff0"
       }
     ]
   },
@@ -35334,7 +36335,12 @@
           "W"
         ],
         "power": "4",
-        "toughness": "4"
+        "toughness": "4",
+        "keywords": [
+          "Flying",
+          "Vigilance"
+        ],
+        "oracle_id": "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
       }
     ]
   },
@@ -35379,7 +36385,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "340aaeb6-cd18-4908-9729-8c53ab02c6f8"
       }
     ]
   },
@@ -35533,7 +36543,9 @@
       {
         "name": "Treasure",
         "type_line": "Token Artifact — Treasure",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "3c549374-6c37-42e0-8d88-a8555d46732d"
       }
     ]
   },
@@ -35693,7 +36705,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -35716,7 +36730,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "2b7dba01-b08c-4218-9fc1-da55559d9155"
       }
     ]
   },
@@ -35768,7 +36784,9 @@
           "W"
         ],
         "power": "*",
-        "toughness": "*"
+        "toughness": "*",
+        "keywords": [],
+        "oracle_id": "9f790267-5be9-41aa-be69-f87a8ce5a29e"
       }
     ]
   },
@@ -35920,7 +36938,11 @@
           "G"
         ],
         "power": "3",
-        "toughness": "3"
+        "toughness": "3",
+        "keywords": [
+          "Toxic"
+        ],
+        "oracle_id": "84a60a2a-82c2-48e1-97ef-da471eb4d80b"
       }
     ]
   },
@@ -35996,7 +37018,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "30272edf-097c-4918-84d2-9fa6c42dbe0a"
       }
     ]
   },
@@ -36019,7 +37043,11 @@
           "G"
         ],
         "power": "7",
-        "toughness": "7"
+        "toughness": "7",
+        "keywords": [
+          "Trample"
+        ],
+        "oracle_id": "ab19c684-94c6-4491-8a6b-7f31dddadae6"
       }
     ]
   },
@@ -36108,7 +37136,9 @@
       {
         "name": "Blood",
         "type_line": "Token Artifact — Blood",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "03f45075-9423-454f-a256-94dcafb2a779"
       }
     ]
   },
@@ -36151,7 +37181,9 @@
       {
         "name": "Food",
         "type_line": "Token Artifact — Food",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "a468338f-635e-4206-89d6-72d723071d45"
       }
     ]
   },
@@ -36220,7 +37252,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "a10bb51d-a921-4f22-bb2f-677aedd2a062"
       }
     ]
   },
@@ -36269,7 +37303,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -36379,7 +37415,9 @@
         "type_line": "Token Creature — Spirit",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "9d73d64b-3ef7-43b0-b0c2-203ab976d564"
       }
     ]
   },
@@ -36540,7 +37578,9 @@
           "B"
         ],
         "power": "0",
-        "toughness": "0"
+        "toughness": "0",
+        "keywords": [],
+        "oracle_id": "620159f8-eb7f-4756-a136-8ad9728adbad"
       }
     ]
   },
@@ -36839,7 +37879,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -36856,7 +37900,11 @@
         "type_line": "Token Artifact Creature — Thopter",
         "colors": [],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Flying"
+        ],
+        "oracle_id": "7c0b6b53-4ddb-4bb5-8a26-0041b2006d3f"
       }
     ]
   },
@@ -37296,7 +38344,11 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [
+          "Food"
+        ],
+        "oracle_id": "a6f7f5c7-8832-40f8-803e-f181571422f8"
       }
     ]
   },
@@ -37317,7 +38369,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -37338,7 +38392,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -37359,7 +38415,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "b2224843-8274-4872-a7ca-2adf69cc066b"
       }
     ]
   },
@@ -37382,7 +38440,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "dac8a765-6845-4b57-bb79-4ec463436f92"
       }
     ]
   },
@@ -37515,7 +38575,9 @@
           "G"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "318d6000-b6e0-4ef0-ad58-d470f4a271e6"
       }
     ]
   },
@@ -37552,7 +38614,11 @@
           "W"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [
+          "Vigilance"
+        ],
+        "oracle_id": "8d7d636d-4ae7-4411-8f45-fc57fead851e"
       }
     ]
   },
@@ -37675,7 +38741,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "1a6c2152-71ca-46be-ab83-c84633442257"
       }
     ]
   },
@@ -37811,7 +38879,9 @@
           "G"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
       }
     ]
   },
@@ -37872,7 +38942,9 @@
           "B"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "ddc8c973-c31e-463f-be45-f3fa7d632362"
       }
     ]
   },
@@ -37898,7 +38970,9 @@
       {
         "name": "Clue",
         "type_line": "Token Artifact — Clue",
-        "colors": []
+        "colors": [],
+        "keywords": [],
+        "oracle_id": "496e1083-c792-40a4-adf4-fec1d559cd5e"
       }
     ]
   },
@@ -37932,7 +39006,9 @@
           "R"
         ],
         "power": "2",
-        "toughness": "2"
+        "toughness": "2",
+        "keywords": [],
+        "oracle_id": "c269bceb-0908-474c-825a-8bc4d138b3d1"
       }
     ]
   },
@@ -37995,7 +39071,9 @@
           "R"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "02d1dc2f-625e-4be3-9daf-e48c44bc9bf7"
       }
     ]
   },
@@ -38018,7 +39096,9 @@
           "W"
         ],
         "power": "1",
-        "toughness": "1"
+        "toughness": "1",
+        "keywords": [],
+        "oracle_id": "a4095286-d51b-4527-b6ce-23aa539fc23a"
       }
     ]
   },

--- a/etc/parsing-scripts/generate_token_index.py
+++ b/etc/parsing-scripts/generate_token_index.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+generate_token_index.py - Build a consolidated token reference from all deck JSONs.
+
+Scans all deck JSON files across every set, collects token data, deduplicates
+by oracle_id (falling back to name+type_line), and records which cards and
+decks in which sets produce each token.
+
+Output: etc/jumpstart-token-index.json
+
+Usage:
+    python generate_token_index.py
+"""
+
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent.parent
+
+SETS = [
+    "JMP", "J22", "J25", "TLA",
+    "ONE", "DMU", "BRO", "MOM",
+    "LTR", "CLU", "FDN", "TLB"
+]
+
+SET_NAMES = {
+    "JMP": "JumpStart 2020",
+    "J22": "JumpStart 2022",
+    "J25": "JumpStart Foundations",
+    "TLA": "Avatar: The Last Airbender",
+    "ONE": "Phyrexia: All Will Be One",
+    "DMU": "Dominaria United",
+    "BRO": "The Brothers' War",
+    "MOM": "March of the Machine",
+    "LTR": "The Lord of the Rings",
+    "CLU": "Ravnica: Clue Edition",
+    "FDN": "Foundations Beginner Box",
+    "TLB": "Avatar TLA Beginner Box",
+}
+
+
+def token_key(token: dict) -> str:
+    """
+    Unique key for deduplicating tokens.
+    Prefer oracle_id (Scryfall's canonical identity); fall back to
+    name + type_line + power/toughness so differently-statted tokens
+    with the same name (e.g. 1/1 Warrior vs 2/2 Warrior) stay separate.
+    """
+    if token.get("oracle_id"):
+        return token["oracle_id"]
+    p = token.get("power", "")
+    t = token.get("toughness", "")
+    return f"{token.get('name','')}|{token.get('type_line','')}|{p}/{t}"
+
+
+def merge_token_data(existing: dict, incoming: dict) -> dict:
+    """
+    Fill in any missing fields on an existing token entry from a newer
+    sighting — useful when early sightings lack keywords/oracle_id.
+    """
+    for field in ("colors", "power", "toughness", "keywords", "oracle_id", "type_line"):
+        if field not in existing and field in incoming:
+            existing[field] = incoming[field]
+        elif field == "keywords" and not existing.get("keywords") and incoming.get("keywords"):
+            existing["keywords"] = incoming["keywords"]
+    return existing
+
+
+def main():
+    print("Scanning deck JSON files...", file=sys.stderr)
+
+    # token_key → { token fields + "sources": [...] }
+    token_map: dict = {}
+    # token_key → set of (set, deck, card) tuples to deduplicate sources
+    seen_sources: dict = defaultdict(set)
+
+    total_decks = 0
+    total_source_refs = 0
+
+    for set_code in SETS:
+        set_dir = BASE_DIR / set_code
+        if not set_dir.exists():
+            print(f"  Warning: {set_code} directory not found", file=sys.stderr)
+            continue
+
+        json_files = sorted(set_dir.glob("*.json"))
+        set_name = SET_NAMES.get(set_code, set_code)
+        print(f"  {set_code}: {len(json_files)} decks", file=sys.stderr)
+
+        for json_file in json_files:
+            with open(json_file) as f:
+                deck = json.load(f)
+
+            deck_name = deck.get("deck_name", json_file.stem)
+            total_decks += 1
+
+            for card in deck.get("cards", []):
+                for token in card.get("tokens", []):
+                    key = token_key(token)
+
+                    # Register token if new
+                    if key not in token_map:
+                        entry: dict = {
+                            "name": token.get("name", ""),
+                            "type_line": token.get("type_line", ""),
+                        }
+                        if "colors" in token:
+                            entry["colors"] = token["colors"]
+                        if "power" in token:
+                            entry["power"] = token["power"]
+                        if "toughness" in token:
+                            entry["toughness"] = token["toughness"]
+                        if token.get("keywords") is not None:
+                            entry["keywords"] = token["keywords"]
+                        if token.get("oracle_id"):
+                            entry["oracle_id"] = token["oracle_id"]
+                        entry["sources"] = []
+                        token_map[key] = entry
+                    else:
+                        merge_token_data(token_map[key], token)
+
+                    # Add source reference (deduplicated per set+deck+card)
+                    source_sig = (set_code, deck_name, card["name"])
+                    if source_sig not in seen_sources[key]:
+                        seen_sources[key].add(source_sig)
+                        token_map[key]["sources"].append({
+                            "set": set_code,
+                            "set_name": set_name,
+                            "deck": deck_name,
+                            "card": card["name"],
+                        })
+                        total_source_refs += 1
+
+    # Sort tokens alphabetically by name, then type_line
+    tokens_sorted = sorted(
+        token_map.values(),
+        key=lambda t: (t["name"].lower(), t.get("type_line", "").lower())
+    )
+
+    # Sort sources within each token: by set order, then deck, then card
+    set_order = {s: i for i, s in enumerate(SETS)}
+    for token in tokens_sorted:
+        token["sources"].sort(key=lambda s: (
+            set_order.get(s["set"], 99),
+            s["deck"],
+            s["card"],
+        ))
+
+    output = {
+        "metadata": {
+            "generated": datetime.now(timezone.utc).isoformat(),
+            "total_tokens": len(tokens_sorted),
+            "total_source_refs": total_source_refs,
+            "decks_scanned": total_decks,
+            "sets": SETS,
+        },
+        "tokens": tokens_sorted,
+    }
+
+    out_file = BASE_DIR / "jumpstart-token-index.json"
+    with open(out_file, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    size_kb = out_file.stat().st_size / 1024
+    print(f"\n{'='*60}", file=sys.stderr)
+    print(f"✓ Generated: {out_file.name}", file=sys.stderr)
+    print(f"  Unique tokens:    {len(tokens_sorted)}", file=sys.stderr)
+    print(f"  Source refs:      {total_source_refs}", file=sys.stderr)
+    print(f"  Decks scanned:    {total_decks}", file=sys.stderr)
+    print(f"  File size:        {size_kb:.1f} KB", file=sys.stderr)
+    print(f"{'='*60}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/etc/parsing-scripts/update_token_keywords.py
+++ b/etc/parsing-scripts/update_token_keywords.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+update_token_keywords.py - Add keywords and oracle_id to cached token data.
+
+Finds all cards in the cache that have tokens missing the 'keywords' field,
+re-queries Scryfall for each card to retrieve token URIs from all_parts, then
+fetches each token URI for keywords and oracle_id. Safe to run multiple times
+— skips tokens that already have the 'keywords' field set.
+
+After running, regenerate deck JSONs with:
+    python generate_json_decks.py ../JMP/ ../J22/ ../J25/ ../TLA/ ...
+And regenerate the combined JSON with:
+    python generate_combined_json.py
+
+Usage:
+    python update_token_keywords.py [options]
+
+Options:
+    --delay MS    Milliseconds between Scryfall API calls (default: 250)
+    --dry-run     Show what would be updated without modifying the cache
+    --limit N     Only process first N cards needing update (for testing)
+    --verbose     Print each token even when no keywords found
+
+Examples:
+    python update_token_keywords.py
+    python update_token_keywords.py --limit 20 --verbose
+    python update_token_keywords.py --dry-run
+"""
+
+import json
+import sys
+import time
+import requests
+from pathlib import Path
+from typing import Dict, List, Optional
+
+CACHE_FILE = Path(__file__).parent / "card_type_cache.json"
+SCRYFALL_NAMED = "https://api.scryfall.com/cards/named"
+
+# 250ms default — well within Scryfall's guidelines
+REQUEST_DELAY = 250 / 1000
+
+# In-memory cache keyed by token URI to avoid re-fetching the same token
+# across multiple cards (e.g. many cards create "Soldier" tokens)
+token_uri_cache: Dict[str, Dict] = {}
+
+
+def fetch_token_by_uri(uri: str) -> Optional[Dict]:
+    """
+    Fetch a token card from Scryfall by URI and extract relevant fields.
+    Results cached in token_uri_cache to avoid duplicate requests.
+    Returns None on failure.
+    """
+    if uri in token_uri_cache:
+        return token_uri_cache[uri]
+
+    try:
+        time.sleep(REQUEST_DELAY)
+        response = requests.get(uri, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        details: Dict = {
+            "colors": data.get("colors", []),
+            "keywords": data.get("keywords", []),
+        }
+        if data.get("power") is not None:
+            details["power"] = data["power"]
+        if data.get("toughness") is not None:
+            details["toughness"] = data["toughness"]
+        if data.get("oracle_id"):
+            details["oracle_id"] = data["oracle_id"]
+
+        token_uri_cache[uri] = details
+        return details
+
+    except requests.exceptions.RequestException as e:
+        print(f"    ✗ Error fetching token {uri}: {e}", file=sys.stderr)
+        token_uri_cache[uri] = None
+        return None
+
+
+def fetch_card_token_parts(card_name: str) -> Optional[List[Dict]]:
+    """
+    Query Scryfall for a card and return token entries from all_parts,
+    each with uri, name, and type_line. Returns None on API failure.
+    """
+    try:
+        time.sleep(REQUEST_DELAY)
+        response = requests.get(SCRYFALL_NAMED, params={"exact": card_name}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        return [
+            {
+                "name": part.get("name", ""),
+                "type_line": part.get("type_line", ""),
+                "uri": part.get("uri", ""),
+            }
+            for part in data.get("all_parts", [])
+            if part.get("component") == "token"
+        ]
+
+    except requests.exceptions.RequestException as e:
+        print(f"  ✗ Error fetching {card_name}: {e}", file=sys.stderr)
+        return None
+
+
+def needs_keyword_update(tokens: List[Dict]) -> bool:
+    """Return True if any token in the list is missing the 'keywords' field."""
+    return any("keywords" not in t for t in tokens)
+
+
+def main():
+    global REQUEST_DELAY
+
+    args = sys.argv[1:]
+    dry_run = "--dry-run" in args
+    verbose = "--verbose" in args
+    limit = None
+    delay_ms = None
+
+    i = 0
+    while i < len(args):
+        if args[i] == "--limit" and i + 1 < len(args):
+            try:
+                limit = int(args[i + 1])
+            except ValueError:
+                print(f"Error: --limit requires an integer, got '{args[i+1]}'", file=sys.stderr)
+                return 1
+            i += 2
+        elif args[i] == "--delay" and i + 1 < len(args):
+            try:
+                delay_ms = int(args[i + 1])
+            except ValueError:
+                print(f"Error: --delay requires an integer (ms), got '{args[i+1]}'", file=sys.stderr)
+                return 1
+            i += 2
+        else:
+            i += 1
+
+    if delay_ms is not None:
+        REQUEST_DELAY = delay_ms / 1000
+        print(f"Scryfall delay: {delay_ms}ms")
+    else:
+        print(f"Scryfall delay: {int(REQUEST_DELAY * 1000)}ms (default)")
+
+    if dry_run:
+        print("DRY RUN — cache will not be modified\n")
+
+    if not CACHE_FILE.exists():
+        print(f"Error: Cache file not found: {CACHE_FILE}", file=sys.stderr)
+        return 1
+
+    with open(CACHE_FILE) as f:
+        cache_data = json.load(f)
+
+    meta = {k: v for k, v in cache_data.items() if k.startswith("_")}
+    cache = {k: v for k, v in cache_data.items() if not k.startswith("_")}
+
+    # Find cards that have tokens and at least one token missing 'keywords'
+    needs_update = [
+        name for name, data in cache.items()
+        if isinstance(data, dict)
+        and data.get("tokens")
+        and needs_keyword_update(data["tokens"])
+    ]
+
+    already_done = sum(
+        1 for data in cache.values()
+        if isinstance(data, dict) and data.get("tokens")
+        and not needs_keyword_update(data["tokens"])
+    )
+
+    print(f"Cards with tokens:        {len(needs_update) + already_done}")
+    print(f"  Already have keywords:  {already_done}")
+    print(f"  Need keyword update:    {len(needs_update)}")
+
+    if not needs_update:
+        print("\nAll token entries already have keywords. Nothing to do.")
+        return 0
+
+    if limit:
+        needs_update = needs_update[:limit]
+        print(f"  Processing first {limit} (--limit)\n")
+    else:
+        print()
+
+    est_seconds = len(needs_update) * REQUEST_DELAY * 2  # ~2 calls per card
+    print(f"Estimated time: ~{est_seconds / 60:.0f} min ({int(REQUEST_DELAY * 1000)}ms/call, ~2 calls/card avg)\n")
+
+    updated_cards = 0
+    updated_tokens = 0
+    api_errors = 0
+
+    for idx, card_name in enumerate(needs_update, 1):
+        print(f"[{idx}/{len(needs_update)}] {card_name}")
+
+        token_parts = fetch_card_token_parts(card_name)
+        if token_parts is None:
+            print(f"  ✗ API error — will retry on next run")
+            api_errors += 1
+            continue
+
+        # Build a URI map from token name for matching
+        uri_map = {p["name"]: p["uri"] for p in token_parts if p["uri"]}
+
+        card_updated = False
+        for token in cache[card_name]["tokens"]:
+            if "keywords" in token:
+                continue  # already done
+
+            token_name = token["name"]
+            uri = uri_map.get(token_name, "")
+
+            if not uri:
+                # URI not found in all_parts — mark as empty to avoid retrying
+                token["keywords"] = []
+                if verbose:
+                    print(f"  {token_name}: no URI found, keywords=[]")
+                card_updated = True
+                continue
+
+            details = fetch_token_by_uri(uri)
+            if details is None:
+                api_errors += 1
+                continue
+
+            token["keywords"] = details.get("keywords", [])
+            if details.get("oracle_id") and "oracle_id" not in token:
+                token["oracle_id"] = details["oracle_id"]
+            # Backfill other fields if missing
+            if "colors" not in token:
+                token["colors"] = details.get("colors", [])
+            if details.get("power") and "power" not in token:
+                token["power"] = details["power"]
+            if details.get("toughness") and "toughness" not in token:
+                token["toughness"] = details["toughness"]
+
+            kw_str = f"[{', '.join(token['keywords'])}]" if token["keywords"] else "(no keywords)"
+            print(f"  {token_name}: keywords={kw_str}")
+            card_updated = True
+            updated_tokens += 1
+
+        if card_updated:
+            updated_cards += 1
+
+        # Incremental save every 25 updated cards
+        if not dry_run and updated_cards > 0 and updated_cards % 25 == 0:
+            _save_cache(meta, cache)
+            print(f"  [checkpoint] Saved ({updated_cards} cards updated so far)")
+
+    if not dry_run and updated_cards > 0:
+        _save_cache(meta, cache)
+        print(f"\nSaved cache.")
+
+    print(f"\nDone.")
+    print(f"  Cards updated:   {updated_cards}")
+    print(f"  Tokens updated:  {updated_tokens}")
+    print(f"  API errors:      {api_errors}")
+    if dry_run:
+        print("  (dry run — nothing written)")
+
+    return 0
+
+
+def _save_cache(meta: Dict, cache: Dict):
+    output = dict(meta)
+    output["_cache_version"] = "2.1"
+    output["_fields"] = "type, type_line, mana_cost, cmc, colors, power, toughness, rarity, tokens, skip_reason(optional)"
+    for name in sorted(cache.keys()):
+        output[name] = cache[name]
+    temp = CACHE_FILE.with_suffix(".json.tmp")
+    with open(temp, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+    temp.replace(CACHE_FILE)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR enriches every deck JSON file across all 12 sets with structured token data, and introduces a consolidated token index for the full collection.

### What changed:

- keywords and oracle_id added to all token objects — every token in every deck JSON now includes its keyword abilities (e.g. ["Flying"], ["Flying", "Vigilance"]) and Scryfall oracle ID for stable cross-set deduplication
- [etc/jumpstart-token-index.json](https://github.com/vibecoder-1z3r0/MTG-JumpStart/blob/claude/add-tla-jumpstart-packs-XxijY/etc/jumpstart-token-index.json) (new) — a single consolidated file listing all 101 unique tokens across all 12 sets, each with its full stats (name, type line, colors, P/T, keywords, oracle_id) and a sources array showing every set/deck/card that produces it (921 source references across 529 decks)
- [etc/parsing-scripts/generate_token_index.py](https://github.com/vibecoder-1z3r0/MTG-JumpStart/blob/claude/add-tla-jumpstart-packs-XxijY/etc/parsing-scripts/generate_token_index.py) (new) — script that scans all deck JSONs and builds the token index; deduplicates by oracle_id with fallback to name+type_line+P/T
- [etc/parsing-scripts/update_token_keywords.py](https://github.com/vibecoder-1z3r0/MTG-JumpStart/blob/claude/add-tla-jumpstart-packs-XxijY/etc/parsing-scripts/update_token_keywords.py) (new) — backfill script that re-queries Scryfall for keywords and oracle_id on tokens that were cached before those fields existed; idempotent and safe to re-run
card_type_cache.json updated — 529 deck JSONs regenerated with token keywords and oracle IDs from the updated cache
- [parsing-scripts/README.md](https://github.com/vibecoder-1z3r0/MTG-JumpStart/blob/claude/add-tla-jumpstart-packs-XxijY/parsing-scripts/README.md) updated — new sections documenting the full JSON/token pipeline and a "starting from scratch / repopulating the cache" guide

## New local pipeline (after formatting .txt files)
```
cd etc/parsing-scripts
python add_token_data.py           # backfill tokens into cache
python update_token_keywords.py    # backfill keywords + oracle_id
python generate_json_decks.py ../JMP/ ../J22/ ../J25/ ../TLA/ ../ONE/ ../DMU/ ../BRO/ ../MOM/ ../LTR/ ../CLU/ ../FDN/ ../TLB/
python generate_combined_json.py
python generate_token_index.py
```

## Token index sample

```
{
  "name": "Angel",
  "type_line": "Token Creature — Angel",
  "colors": ["W"],
  "power": "4",
  "toughness": "4",
  "keywords": ["Flying"],
  "oracle_id": "...",
  "sources": [
    { "set": "JMP", "set_name": "JumpStart 2020", "deck": "ANGELS (1)", "card": "Serra Angel" },
    ...
  ]
}
```

## Files changed
- 380 deck JSON files updated (all 12 sets)
- 3 new scripts (generate_token_index.py, update_token_keywords.py, plus minor additions to add_token_data.py and batch_reformat.py)
- card_type_cache.json — keywords + oracle_id backfilled for all token-producing cards
- README.md — pipeline and cache rebuild documentation added